### PR TITLE
Add sprite entity types (TextSprite, Sprite)

### DIFF
--- a/Config/EngineConfig.json
+++ b/Config/EngineConfig.json
@@ -60,7 +60,7 @@
   },
   "System": {
     "SelectedGpu": {
-      "Index": 0
+      "Index": 1
     }
   },
   "Baker": {

--- a/Config/EngineConfig.json
+++ b/Config/EngineConfig.json
@@ -60,7 +60,7 @@
   },
   "System": {
     "SelectedGpu": {
-      "Index": 1
+      "Index": 0
     }
   },
   "Baker": {

--- a/Config/EngineConfig.json
+++ b/Config/EngineConfig.json
@@ -50,6 +50,18 @@
     },
     "Vulkan": {
       "DebugLayers": false
+    },
+    "RayTracing": {
+      "Enabled": false,
+      "Reflections": {
+        "Enabled": false
+      },
+      "GI": {
+        "Enabled": false
+      },
+      "PathTracing": {
+        "Enabled": false
+      }
     }
   },
   "Editor": {

--- a/Data/Scripts/Lib.hyp
+++ b/Data/Scripts/Lib.hyp
@@ -693,8 +693,9 @@ extern enum ViewFlags : uint32
     SKIP_PARTICLE_VOLUMES = 0x200,
     SKIP_FOG_VOLUMES = 0x400,
     SKIP_CAMERAS = 0x800,
-    NOT_MULTI_BUFFERED = 0x1000,
-    NO_DRAW_CALLS = 0x2000,
+    SKIP_SPRITES = 0x1000,
+    NOT_MULTI_BUFFERED = 0x2000,
+    NO_DRAW_CALLS = 0x4000,
     RAY_TRACING = 0x100000,
     MATCH_CAMERA_DIMENSIONS = 0x200000,
     SHADOW_VIEW = 0x400000,
@@ -1779,8 +1780,6 @@ extern class AssetObject
     SetFriendlyName(friendlyName : Name) -> void
     GetAssetIndex() -> uint32
     IsRegistered() -> bool
-    GetOriginalFilepath() -> string
-    SetOriginalFilepath(originalFilepath : string) -> void
     GetPath() -> AssetPath
     GetAssetFlags() -> AssetObjectFlags
     SetAssetFlags(flags : AssetObjectFlags) -> void
@@ -1793,7 +1792,6 @@ extern class AssetObject
     Name : Name
     FriendlyName : Name
     Flags : AssetObjectFlags
-    OriginalFilepath : string
     AssetIndex : uint32
     AssetPath : AssetPath
 end
@@ -2229,7 +2227,10 @@ extern enum SpriteType : uint32
     EnvProbe,
     LightmapVolume,
     Camera,
+    Text,
     Max
+end
+extern class TextSprite : Sprite
 end
 extern class Light : Entity
     GetLightType() -> LightType

--- a/Data/Scripts/Lib.hyp
+++ b/Data/Scripts/Lib.hyp
@@ -1110,6 +1110,7 @@ extern enum GlobalRendererType : uint32
     GRT_ENV_GRID,
     GRT_SHADOW_MAP,
     GRT_PARTICLE_VOLUME,
+    GRT_SPRITE,
     GRT_SSAO,
     GRT_MAX
 end

--- a/Data/Scripts/Lib.hyp
+++ b/Data/Scripts/Lib.hyp
@@ -15,514 +15,227 @@ const DBL_MAX : double = 1.7976931348623157e+308
 const DBL_MIN : double = 2.2250738585072014e-308
 const DBL_EPSILON : double = 2.2204460492503131e-16
 
-extern struct OctantId
+extern class EditorCommandBase
+    GetText() -> string
+    GetArguments() -> Array<string>
+    SetArguments(args : Array<string>) -> void
+    NumArguments() -> int
+    GetArgument(index : int) -> string
 end
-extern class OverlayBase
-    GetUIObject() -> UIObject
-    GetPlacement() -> int
-    Update(delta : float) -> void
-    CreateUIObject(spawnParent : UIObject) -> UIObject
-    IsEnabled() -> bool
-    CreateUIObject_Impl(spawnParent : UIObject) -> UIObject
-    GetPlacement_Impl() -> int
-    Update_Impl(delta : float) -> void
-    IsEnabled_Impl() -> bool
+extern class EditorTaskBase
+    GetTitle() -> string
+    GetDescription() -> string
+    SetDescription(description : string) -> void
+    GetProgress() -> float
+    SetProgress(progress : float) -> void
+    IsCancellationRequested() -> bool
+    IsCommitted() -> bool
+    Start() -> void
+    Cancel() -> void
+    IsCompleted() -> bool
+    Commit() -> bool
+    OnComplete : any
+    OnCancel : any
+    OnDescriptionChange : any
 end
-extern class NullOverlay : OverlayBase
+extern class TickableEditorTask : EditorTaskBase
+    IsForegroundTask() -> bool
+    SetIsForegroundTask(isForeground : bool) -> void
+    Start() -> void
+    Cancel() -> void
+    IsCompleted() -> bool
+    Commit() -> bool
+    Tick() -> void
+    Start_Impl() -> void
+    Cancel_Impl() -> void
+    IsCompleted_Impl() -> bool
+    Tick_Impl() -> void
 end
-extern class TextureOverlay : OverlayBase
-    CreateUIObject_Impl(spawnParent : UIObject) -> UIObject
-    GetPlacement_Impl() -> int
+extern class LongRunningEditorTask : EditorTaskBase
+    Start() -> void
+    Cancel() -> void
+    IsCompleted() -> bool
+    Process() -> void
+    Commit() -> bool
+    Start_Impl() -> void
+    Cancel_Impl() -> void
+    IsCompleted_Impl() -> bool
+    Process_Impl() -> void
 end
-extern class TextOverlay : OverlayBase
-    CreateUIObject_Impl(spawnParent : UIObject) -> UIObject
+extern class EditorActionBase
+    GetText() -> string
+    Execute(editorSubsystem : EditorSubsystem, project : EditorProject) -> void
+    Revert(editorSubsystem : EditorSubsystem, project : EditorProject) -> void
 end
-extern class StatsOverlay : OverlayBase
-    CreateUIObject_Impl(spawnParent : UIObject) -> UIObject
-    GetPlacement_Impl() -> int
-    Update_Impl(delta : float) -> void
-    IsEnabled_Impl() -> bool
+extern class FunctionalEditorAction : EditorActionBase
+    GetText() -> string
+    Execute(editorSubsystem : EditorSubsystem, project : EditorProject) -> void
+    Revert(editorSubsystem : EditorSubsystem, project : EditorProject) -> void
 end
-extern class DeviceDetailsOverlay : OverlayBase
-    CreateUIObject_Impl(spawnParent : UIObject) -> UIObject
-    GetPlacement_Impl() -> int
-    Update_Impl(delta : float) -> void
-    IsEnabled_Impl() -> bool
-end
-extern class ConsoleOverlay : OverlayBase
-    CreateUIObject_Impl(spawnParent : UIObject) -> UIObject
-    GetPlacement_Impl() -> int
-    Update_Impl(delta : float) -> void
-    IsEnabled_Impl() -> bool
-end
-extern class BaseStatsOverlay : OverlayBase
-    CreateUIObject_Impl(spawnParent : UIObject) -> UIObject
-    GetPlacement_Impl() -> int
-    Update_Impl(delta : float) -> void
-    IsEnabled_Impl() -> bool
-end
-extern struct GlyphMetrics
-    Width : uint16
-    Height : uint16
-    BearingX : int16
-    BearingY : int16
-    Advance : uint32
-    ImagePosition : Vec2i
-end
-extern enum ScrollAxis : uint8
-    SA_NONE = 0x0,
-    SA_HORIZONTAL = 0x1,
-    SA_VERTICAL = 0x2,
-    SA_ALL = (SA_HORIZONTAL | SA_VERTICAL)
-end
-extern enum UIObjectFocusState : uint32
-    NONE = 0x0,
-    HOVER = 0x1,
-    PRESSED = 0x2,
-    TOGGLED = 0x4,
-    FOCUSED = 0x8
-end
-extern enum UIObjectUpdateType : uint32
-    NONE = 0x0,
-    UPDATE_SIZE = 0x1,
-    UPDATE_POSITION = 0x2,
-    UPDATE_MATERIAL = 0x4,
-    UPDATE_MESH_DATA = 0x8,
-    UPDATE_COMPUTED_VISIBILITY = 0x10,
-    UPDATE_CLAMPED_SIZE = 0x20,
-    UPDATE_CUSTOM = 0x40,
-    UPDATE_ALL = UINT16_MAX,
-    UPDATE_CHILDREN_SIZE = (UPDATE_SIZE << 16),
-    UPDATE_CHILDREN_POSITION = (UPDATE_POSITION << 16),
-    UPDATE_CHILDREN_MATERIAL = (UPDATE_MATERIAL << 16),
-    UPDATE_CHILDREN_MESH_DATA = (UPDATE_MESH_DATA << 16),
-    UPDATE_CHILDREN_COMPUTED_VISIBILITY = (UPDATE_COMPUTED_VISIBILITY << 16),
-    UPDATE_CHILDREN_CLAMPED_SIZE = (UPDATE_CLAMPED_SIZE << 16),
-    UPDATE_CHILDREN_CUSTOM = (UPDATE_CUSTOM << 16),
-    UPDATE_CHILDREN_ALL = (UPDATE_ALL << 16)
-end
-extern enum UIObjectBorderFlags : uint32
-    NONE = 0x0,
-    TOP = 0x1,
-    LEFT = 0x2,
-    BOTTOM = 0x4,
-    RIGHT = 0x8,
-    ALL = (((TOP | LEFT) | BOTTOM) | RIGHT)
-end
-extern struct UIEventHandlerResult
-end
-extern enum UIObjectAlignment : uint32
-    TOP_LEFT = 0,
-    TOP_RIGHT = 1,
-    CENTER = 2,
-    BOTTOM_LEFT = 3,
-    BOTTOM_RIGHT = 4
-end
-extern enum UIObjectUpdateSizeFlags : uint32
-    NONE = 0x0,
-    MAX_SIZE = 0x1,
-    INNER_SIZE = 0x2,
-    OUTER_SIZE = 0x4,
-    DEFAULT = ((MAX_SIZE | INNER_SIZE) | OUTER_SIZE)
-end
-extern struct UIObjectAspectRatio
-    X : float
-    Y : float
-end
-extern struct UIObjectSize
-    Flags : uint64
-    Value : Vec2i
-end
-extern class UIObject
-    GetEntity() -> Entity
-    GetStage() -> UIStage
-    SetStage(stage : UIStage) -> void
+extern class EditorProject
     GetName() -> Name
     SetName(name : Name) -> void
-    GetPosition() -> Vec2i
-    SetPosition(position : Vec2i) -> void
-    GetOffsetPosition() -> Vec2f
-    GetAbsolutePosition() -> Vec2f
-    IsPositionAbsolute() -> bool
-    SetIsPositionAbsolute(isPositionAbsolute : bool) -> void
-    GetSize() -> UIObjectSize
-    SetSize(size : UIObjectSize) -> void
-    GetInnerSize() -> UIObjectSize
-    SetInnerSize(size : UIObjectSize) -> void
-    GetMaxSize() -> UIObjectSize
-    SetMaxSize(size : UIObjectSize) -> void
-    GetActualSize() -> Vec2i
-    GetActualSizeClamped() -> Vec2i
-    GetActualInnerSize() -> Vec2i
-    GetScrollOffset() -> Vec2f
-    SetScrollOffset(scrollOffset : Vec2f, smooth : bool) -> void
-    ScrollToChild(child : UIObject) -> void
-    GetVerticalScrollbarSize() -> int
-    GetHorizontalScrollbarSize() -> int
-    CanScrollOnAxis(axis : ScrollAxis) -> bool
-    GetComputedDepth() -> int
-    GetDepth() -> int
-    SetDepth(depth : int) -> void
-    AcceptsFocus() -> bool
-    SetAcceptsFocus(acceptsFocus : bool) -> void
-    NeedsUpdate() -> bool
-    Focus() -> void
-    Blur(blurChildren : bool) -> void
-    SetAffectsParentSize(affectsParentSize : bool) -> void
-    AffectsParentSize() -> bool
-    GetBorderRadius() -> uint32
-    SetBorderRadius(borderRadius : uint32) -> void
-    GetBorderFlags() -> UIObjectBorderFlags
-    SetBorderFlags(borderFlags : UIObjectBorderFlags) -> void
-    GetAspectRatio() -> UIObjectAspectRatio
-    SetAspectRatio(aspectRatio : UIObjectAspectRatio) -> void
-    GetPadding() -> Vec2i
-    SetPadding(padding : Vec2i) -> void
-    GetBackgroundColor() -> Color
-    SetBackgroundColor(backgroundColor : Color) -> void
-    GetTextColor() -> Color
-    SetTextColor(textColor : Color) -> void
-    GetText() -> string
-    SetText(text : string) -> void
-    GetTextSize() -> float
-    SetTextSize(textSize : float) -> void
-    IsVisible() -> bool
-    SetIsVisible(isVisible : bool) -> void
-    IsEnabled() -> bool
-    SetIsEnabled(isEnabled : bool) -> void
-    GetParentUIObject() -> UIObject
-    AddChildUIObject(uiObject : UIObject) -> void
-    RemoveChildUIObject(uiObject : UIObject) -> bool
-    ClearDeep() -> void
-    RemoveFromParent() -> bool
-    DetachFromParent() -> UIObject
-    HasChildUIObjects() -> bool
-    GetChildUIObject(index : int) -> UIObject
-    NumChildUIObjects(deep : bool) -> uint32
-    GetNode() -> Node
     GetWorld() -> World
-    GetAABB() -> BoundingBox
-    GetAABBClamped() -> BoundingBox
-    GetDataSource() -> UIDataSourceBase
-    SetDataSource(dataSource : UIDataSourceBase) -> void
-    OnInit : any
-    OnAttached : any
-    OnRemoved : any
-    OnChildAttached : any
-    OnChildRemoved : any
-    OnMouseDown : any
-    OnMouseUp : any
-    OnMouseDrag : any
-    OnMouseHover : any
-    OnMouseLeave : any
-    OnMouseMove : any
-    OnGainFocus : any
-    OnLoseFocus : any
-    OnScroll : any
-    OnClick : any
-    OnRightClick : any
-    OnKeyDown : any
-    OnKeyUp : any
-    OnTextChange : any
-    OnSizeChange : any
-    OnComputedVisibilityChange : any
-    OnEnabled : any
-    OnDisabled : any
-    OnValueChange : any
-    Init() -> void
+    GetGame() -> Game
+    SetGame(gameInstance : Game) -> void
+    GetLastSavedTime() -> Time
+    GetFilePath() -> string
+    AddScene(scene : Scene) -> void
+    RemoveScene(scene : Scene) -> void
+    GetProjectsDirectory() -> string
+    IsSaved() -> bool
+    Save() -> Result
+    SaveAs(filepath : string) -> Result
+    GetActionStack() -> EditorActionStack
+    Close() -> void
+    OnProjectSaved : any
+    Name : Name
+    LastSavedTime : Time
+    Filepath : string
+    GameInstance : Game
+    ActionStack : EditorActionStack
 end
-extern class UIConsole : UIObject
+extern class EditorState
+    static GetInstance() -> EditorState
+    GetCurrentProject() -> EditorProject
+    SetCurrentProject(project : EditorProject) -> void
+    AddTask(task : EditorTaskBase) -> void
+    OnCurrentProjectChanged : any
+    OnTaskStarted : any
+    OnTaskEnded : any
+    OnTaskProgressUpdated : any
 end
-extern class UIText : UIObject
-    GetCharacterOffset(characterIndex : int) -> Vec2f
-end
-extern class UIStage : UIObject
-    GetSurfaceSize() -> Vec2i
-    SetSurfaceSize(surfaceSize : Vec2i) -> void
-    GetScene() -> Scene
-    SetScene(scene : Scene) -> void
+extern class EditorViewport
     GetCamera() -> Camera
+    GetView() -> View
+    GetWindow() -> ApplicationWindow
+    CreateViewportWindow(options : WindowOptions) -> ApplicationWindow
 end
-extern class UISpacer : UIObject
-end
-extern class UIPanel : UIObject
-    IsHorizontalScrollEnabled() -> bool
-    IsVerticalScrollEnabled() -> bool
-    SetIsScrollEnabled(axis : ScrollAxis, isScrollEnabled : bool) -> void
-end
-extern class UIWindow : UIPanel
-end
-extern class UITextbox : UIPanel
-    GetPlaceholder() -> string
-    SetPlaceholder(placeholder : string) -> void
-    GetPlaceholderTextColor() -> Color
-    ClearOnSubmit : bool
-end
-extern class UITabView : UIPanel
-end
-extern class UITab : UIObject
-end
-extern class UIMenuBar : UIPanel
-    GetDropDirection() -> UIMenuBarDropDirection
-    SetDropDirection(dropDirection : UIMenuBarDropDirection) -> void
-    SetSelectedMenuItemIndex(index : uint32) -> void
-    AddMenuItem(name : Name, text : string) -> UIMenuItem
-    GetMenuItem(name : Name) -> UIMenuItem
-    GetMenuItemIndex(name : Name) -> uint32
-    RemoveMenuItem(name : Name) -> bool
-end
-extern class UIMenuItem : UIObject
-end
-extern enum UIMenuBarDropDirection : uint32
-    DOWN,
-    UP
-end
-extern enum UIListViewOrientation : uint8
-    VERTICAL = 0,
-    HORIZONTAL
-end
-extern class UIListView : UIPanel
-    SetSelectedItem(listViewItem : UIListViewItem) -> void
-    GetSelectedItemIndex() -> int
-    SetSelectedItemIndex(index : int) -> void
-    GetOrientation() -> UIListViewOrientation
-    SetOrientation(orientation : UIListViewOrientation) -> void
-end
-extern class UIListViewItem : UIObject
-end
-extern class UIGrid : UIPanel
-    GetNumColumns() -> int
-    SetNumColumns(numColumns : int) -> void
-    GetNumRows() -> uint32
-    SetNumRows(numRows : uint32) -> void
-end
-extern class UIGridRow : UIPanel
-end
-extern class UIGridColumn : UIPanel
-    GetColumnSize() -> int
-    SetColumnSize(columnSize : int) -> void
-end
-extern class UIDockableContainer : UIPanel
-end
-extern class UIDockableItem : UIPanel
-end
-extern class EditorPropertyPanelBase : UIPanel
-    Build(boxed : any, property : any) -> void
-end
-extern class UIImage : UIObject
-end
-extern class UIButton : UIObject
-end
-extern class UIDataSourceBase
-    Size() -> int
-    Clear() -> void
-end
-extern class UIDataSource : UIDataSourceBase
-    Size() -> int
-    Clear() -> void
-end
-extern class UIElementFactoryBase
-    GetElementTypeId() -> TypeId
-    CreateUIObject(parent : UIObject, value : any, context : any) -> UIObject
-    UpdateUIObject(uiObject : UIObject, value : any, context : any) -> void
-end
-extern class ApplicationWindow
-    GetInputManager() -> InputManager
-    GetHWND() -> any
-    GetSize() -> Vec2i
-    SetMousePosition(position : Vec2i) -> void
-    GetMousePosition() -> Vec2i
-    SetIsMouseLocked(locked : bool) -> void
-    IsMouseLocked() -> bool
-    HasMouseFocus() -> bool
-    IsHighDPI() -> bool
-    GetDimensions() -> Vec2i
-    Close() -> void
-    OnWindowSizeChanged : any
-    OnClose : any
-end
-extern class AndroidApplicationWindow : ApplicationWindow
-    SetMousePosition(position : Vec2i) -> void
-    GetMousePosition() -> Vec2i
-    GetDimensions() -> Vec2i
-    SetIsMouseLocked(locked : bool) -> void
-    IsMouseLocked() -> bool
-    HasMouseFocus() -> bool
-    Close() -> void
-end
-extern class SDLApplicationWindow : ApplicationWindow
-    SetMousePosition(position : Vec2i) -> void
-    GetMousePosition() -> Vec2i
-    GetDimensions() -> Vec2i
-    SetIsMouseLocked(locked : bool) -> void
-    IsMouseLocked() -> bool
-    HasMouseFocus() -> bool
-    IsHighDPI() -> bool
-    Close() -> void
-end
-extern class CocoaApplicationWindow : ApplicationWindow
-    SetMousePosition(position : Vec2i) -> void
-    GetMousePosition() -> Vec2i
-    GetDimensions() -> Vec2i
-    SetIsMouseLocked(locked : bool) -> void
-    IsMouseLocked() -> bool
-    HasMouseFocus() -> bool
-    IsHighDPI() -> bool
-    GetNSWindow() -> any
-    GetNSView() -> any
-    Close() -> void
-end
-extern class Win32ApplicationWindow : ApplicationWindow
-    SetMousePosition(position : Vec2i) -> void
-    GetMousePosition() -> Vec2i
-    GetDimensions() -> Vec2i
-    SetIsMouseLocked(locked : bool) -> void
-    IsMouseLocked() -> bool
-    HasMouseFocus() -> bool
-    Close() -> void
-end
-extern class AppContextBase
-    static GetInstance() -> AppContextBase
-    GetAppName() -> string
-    GetMainWindow() -> ApplicationWindow
-    SetMainWindow(window : ApplicationWindow) -> void
-    GetWindows() -> Array<ApplicationWindow>
-    CreateSystemWindow(windowOptions : WindowOptions) -> ApplicationWindow
-    RemoveWindow(window : ApplicationWindow) -> void
-    RunCommandlet(commandletName : string, args : CommandLineArguments) -> Result
-    OnCurrentWindowChanged : any
-end
-extern class Win32AppContext : AppContextBase
-    CreateSystemWindow(windowOptions : WindowOptions) -> ApplicationWindow
-end
-extern class AndroidAppContext : AppContextBase
-    CreateSystemWindow(windowOptions : WindowOptions) -> ApplicationWindow
-end
-extern class SDLAppContext : AppContextBase
-    CreateSystemWindow(windowOptions : WindowOptions) -> ApplicationWindow
-end
-extern class CocoaAppContext : AppContextBase
-    CreateSystemWindow(windowOptions : WindowOptions) -> ApplicationWindow
-end
-extern struct WindowOptions
-end
-extern enum WindowFlags : uint32
+extern enum EditorActionStackState : uint32
     NONE = 0x0,
-    HEADLESS = 0x1,
-    NO_GFX = 0x2,
-    HIGH_DPI = 0x4,
-    EVENTS_POLLING = 0x8
+    CAN_UNDO = 0x1,
+    CAN_REDO = 0x2
 end
-extern class StreamingVolumeBase
-    GetShape() -> StreamingVolumeShape
-    GetBoundingBox(outAabb : BoundingBox) -> bool
-    GetBoundingSphere(outSphere : BoundingSphere) -> bool
-    ContainsPoint(point : Vec3f) -> bool
-    GetShape_Impl() -> StreamingVolumeShape
-    GetBoundingBox_Impl(outAabb : BoundingBox) -> bool
-    GetBoundingSphere_Impl(outSphere : BoundingSphere) -> bool
-    ContainsPoint_Impl(point : Vec3f) -> bool
-    NotifyUpdate() -> void
+extern class EditorActionStack
+    PushAction(action : EditorActionBase) -> bool
+    CanUndo() -> bool
+    CanRedo() -> bool
+    Undo() -> void
+    Redo() -> void
+    GetUndoAction() -> EditorActionBase
+    GetRedoAction() -> EditorActionBase
+    OnBeforeActionPush : any
+    OnBeforeActionPop : any
+    OnAfterActionPush : any
+    OnAfterActionPop : any
+    OnStateChange : any
 end
-extern enum StreamingVolumeShape : uint32
-    SPHERE = 0,
-    BOX,
-    MAX,
-    INVALID = ~0u
+extern class CommandletBase
+    static GetArgumentDefinitions() -> CommandLineArgumentDefinitions
+    Run(args : CommandLineArguments) -> Result
+    Run_Impl(args : CommandLineArguments) -> Result
 end
-extern class StreamingManager
-    AddStreamingVolume(volume : StreamingVolumeBase) -> void
-    RemoveStreamingVolume(volume : StreamingVolumeBase) -> void
+extern class EngineDriver
+    static GetInstance() -> EngineDriver
+    GetCurrentWorld() -> World
+    SetCurrentWorld(world : World) -> void
+    GetDefaultWorld() -> World
+    SetDefaultWorld(defaultWorld : World) -> void
+    SetGameInstance(gameInstance : Game) -> void
+    GetGameInstance() -> Game
 end
-extern class StreamableBase
-    GetBoundingBox() -> BoundingBox
-    OnStreamStart() -> void
-    OnLoaded() -> void
-    OnRemoved() -> void
-    GetBoundingBox_Impl() -> BoundingBox
-    OnStreamStart_Impl() -> void
-    OnLoaded_Impl() -> void
-    OnRemoved_Impl() -> void
+extern class EngineStats
+    static GetInstance() -> EngineStats
+    GetFps() -> double
+    GetMsPerFrame() -> double
+    QueryStatValue(path : string, valueIfNotFound : double) -> double
 end
-extern enum StreamingCellState : uint32
-    INVALID = ~0u,
-    UNLOADED = 0,
-    UNLOADING,
-    WAITING,
-    LOADING,
-    LOADED,
-    MAX
+extern enum EnginePoolName : int
+    EPN_INVALID = -1,
+    EPN_CORE = 0,
+    EPN_RENDER,
+    EPN_SCENE,
+    EPN_MAX
 end
-extern class StreamingCell : StreamableBase
-    GetPatchInfo() -> StreamingCellInfo
-    Update(delta : float) -> void
-    GetBoundingBox_Impl() -> BoundingBox
-    Update_Impl(delta : float) -> void
+extern enum GpuType : uint8
+    Unknown = 0,
+    Integrated,
+    Dedicated
 end
-extern struct StreamingCellInfo
-    Coord : Vec2i
-    Extent : Vec3u
-    Scale : Vec3f
-    Bounds : BoundingBox
+extern class DeviceDetails
+    GetGpuType() -> GpuType
+    GetGpuVendor() -> GpuVendor
+    GetGpuModel() -> string
+    GetGpuVendorName() -> string
+    GetDriverVersion() -> string
+    IsDiscreteGpu() -> bool
+    SupportsRayTracing() -> bool
+    SupportsRayQueries() -> bool
+    SupportsVariableRateShading() -> bool
+    SupportsSamplerFeedback() -> bool
+    SupportsBindless() -> bool
 end
-extern struct StreamingCellNeighbor
-    Coord : Vec2i
+extern enum GpuVendor : uint8
+    Unknown = 0,
+    Nvidia,
+    Amd,
+    Intel,
+    Qualcomm,
+    Apple,
+    Microsoft
 end
-extern class TerrainStreamingCell : StreamingCell
-    OnStreamStart_Impl() -> void
-    OnLoaded_Impl() -> void
-    OnRemoved_Impl() -> void
+extern class Game
+    GetAssetRegistry() -> AssetRegistry
+    SetAssetRegistry(assetRegistry : AssetRegistry) -> void
+    GetWorld() -> World
+    SetWorld(world : World) -> void
+    GetGameState() -> GameState
+    OnLaunch() -> void
+    OnUpdate(delta : float) -> void
+    Initialize() -> void
+    Shutdown() -> void
+    SetToEditMode() -> void
+    IsLaunched() -> bool
+    StartSimulating() -> void
+    StopSimulating() -> void
+    PauseSimulation() -> void
+    OnLaunched : any
+    OnGameStateChange : any
+    OnLaunch_Impl() -> void
+    OnUpdate_Impl(delta : float) -> void
+    World : World
+    GameState : GameState
 end
-extern enum ScriptLanguage : uint32
-    Invalid = ~0u,
-    Native = 0,
-    HypScript = 1,
-    CSharp = 2
+extern enum GameStateMode : uint32
+    STOPPED = 0,
+    SIMULATING,
+    PAUSED,
+    EDIT_MODE
 end
-extern enum ScriptCompileStatus : uint32
-    Uninitialized = 0x0,
-    Compiled = 0x1,
-    Dirty = 0x2,
-    Processing = 0x4,
-    Errored = 0x8
+extern struct GameState
+    Mode : GameStateMode
+    DeltaTime : float
+    GameTime : float
+    IsStopped() -> bool
+    IsSimulating() -> bool
+    IsPaused() -> bool
+    IsEditMode() -> bool
 end
-extern struct ScriptDesc
-    Uuid : UUID
-    Language : ScriptLanguage
-    Path : Array<any>
-    AssemblyPath : Array<any>
-    ClassName : Array<any>
-    CompileStatus : uint32
-    HotReloadVersion : int32
-    LastModifiedTimestamp : uint64
+extern struct WGLayerDesc
+    ClassName : Name
+    LayerName : Name
+    Info : WorldGridLayerInfo
+    Objects : Array<WGObject>
 end
-extern struct PropertyHandle
+extern struct WGObject
+    Coords : Vec2i
+    Path : AssetPath
 end
-extern struct FieldHandle
-end
-extern struct MethodHandle
-end
-extern class Reflection
-    static GetClassByName(name : Name) -> Class
-    static GetFields(classRef : Class) -> Array<FieldHandle>
-    static GetFieldHandle(classRef : Class, fieldName : Name) -> FieldHandle
-    static GetFieldValue(field : FieldHandle, target : any) -> any
-    static SetFieldValue(field : FieldHandle, target : any, value : any) -> void
-    static GetFieldName(field : FieldHandle) -> Name
-    static GetMethods(classRef : Class) -> Array<MethodHandle>
-    static GetMethodHandle(classRef : Class, methodName : Name) -> MethodHandle
-    static InvokeMethod(method : MethodHandle, args : Array<any>) -> any
-    static GetMethodName(method : MethodHandle) -> Name
-    static GetProperties(classRef : Class) -> Array<PropertyHandle>
-    static GetPropertyHandle(classRef : Class, propertyName : Name) -> PropertyHandle
-    static GetPropertyValue(property : PropertyHandle, target : any) -> any
-    static SetPropertyValue(property : PropertyHandle, target : any, value : any) -> void
-    static GetPropertyName(property : PropertyHandle) -> Name
-end
-extern class Debugger
-    static Breakpoint() -> void
-    static AssertTrue(condition : bool) -> void
-    static AssertFalse(condition : bool) -> void
+extern class WorldGrid
+    GetWorld() -> World
+    AddLayer(layer : WorldGridLayer) -> void
+    RemoveLayer(layer : WorldGridLayer) -> bool
+    GetLayers() -> Array<WorldGridLayer>
 end
 extern class WorldGridLayer
     GetName() -> Name
@@ -553,76 +266,10 @@ extern class TerrainWorldGridLayer : WorldGridLayer
     OnRemoved_Impl(worldGrid : WorldGrid) -> void
     CreateStreamingCell_Impl(cellInfo : StreamingCellInfo) -> StreamingCell
 end
-extern struct WGLayerDesc
-    ClassName : Name
-    LayerName : Name
-    Info : WorldGridLayerInfo
-    Objects : Array<WGObject>
-end
-extern struct WGObject
-    Coords : Vec2i
-    Path : AssetPath
-end
-extern class WorldGrid
-    GetWorld() -> World
-    AddLayer(layer : WorldGridLayer) -> void
-    RemoveLayer(layer : WorldGridLayer) -> bool
-    GetLayers() -> Array<WorldGridLayer>
-end
-extern struct VisibilityStateComponent
-    Flags : VisibilityStateFlags
-    OctantId : OctantId
-    VisibilityState : VisibilityState
-end
-extern enum VisibilityStateFlags : uint32
-    NONE = 0x0,
-    ALWAYS_VISIBLE = 0x1,
-    INVALIDATED = 0x2
-end
-extern struct UIComponent
-    UiObject : any
-end
-extern struct TransformComponent
-    Translation : Vec3f
-    Rotation : Quat4f
-    Scale : Vec3f
-end
-extern enum ScriptComponentFlags : uint32
-    NONE = 0x0,
-    INITIALIZED = 0x1,
-    RELOADING = 0x2,
-    INITIALIZATION_STARTED = 0x4,
-    BEFORE_ADDED_CALLED = 0x10,
-    ON_ADDED_CALLED = 0x20
-end
 extern struct RigidBodyComponent
     PhysicsMaterial : PhysicsMaterial
     Shape : PhysicsShape
     RigidBody : RigidBody
-end
-extern struct MeshComponent
-    Mesh : Mesh
-    Material : MaterialInstance
-    Skeleton : Skeleton
-    EnableAutoInstancing : bool
-    NumInstances : uint32
-    PreviousModelMatrix : Mat4f
-end
-extern struct CharacterControllerComponent
-    Shape : PhysicsShape
-    InputHandler : InputHandlerBase
-    PhysicsHandle : void
-    ViewDirection : Vec3f
-    Translation : Vec3f
-    MoveSpeed : float
-    StepHeight : float
-    MaxSlopeAngle : float
-    JumpSpeed : float
-    FallSpeed : float
-    IsOnGround : bool
-end
-extern struct BoundingBoxComponent
-    WorldAabb : BoundingBox
 end
 extern struct AudioPlaybackState
     Status : AudioPlaybackStatus
@@ -669,14 +316,69 @@ end
 extern struct AnimationComponent
     PlaybackState : AnimationPlaybackState
 end
+extern struct CharacterControllerComponent
+    Shape : PhysicsShape
+    InputHandler : InputHandlerBase
+    PhysicsHandle : void
+    ViewDirection : Vec3f
+    Translation : Vec3f
+    MoveSpeed : float
+    StepHeight : float
+    MaxSlopeAngle : float
+    JumpSpeed : float
+    FallSpeed : float
+    IsOnGround : bool
+end
+extern struct UIComponent
+    UiObject : any
+end
+extern enum ScriptComponentFlags : uint32
+    NONE = 0x0,
+    INITIALIZED = 0x1,
+    RELOADING = 0x2,
+    INITIALIZATION_STARTED = 0x4,
+    BEFORE_ADDED_CALLED = 0x10,
+    ON_ADDED_CALLED = 0x20
+end
+extern struct TransformComponent
+    Translation : Vec3f
+    Rotation : Quat4f
+    Scale : Vec3f
+end
+extern struct BoundingBoxComponent
+    WorldAabb : BoundingBox
+end
+extern struct VisibilityStateComponent
+    Flags : VisibilityStateFlags
+    OctantId : OctantId
+    VisibilityState : VisibilityState
+end
+extern enum VisibilityStateFlags : uint32
+    NONE = 0x0,
+    ALWAYS_VISIBLE = 0x1,
+    INVALIDATED = 0x2
+end
+extern struct MeshComponent
+    Mesh : Mesh
+    Material : MaterialInstance
+    Skeleton : Skeleton
+    EnableAutoInstancing : bool
+    NumInstances : uint32
+    PreviousModelMatrix : Mat4f
+end
 extern struct Keyframe
     Time : float
     Transform : Transform
     Blend(to : Keyframe, blend : float) -> Keyframe
 end
-extern struct VisibilityStateSnapshot
+extern class EntityManager
+    GetWorld() -> World
+    GetScene() -> Scene
+    AddExistingEntity(entity : Entity) -> void
+    AddTypedEntity(cls : Class) -> Entity
+    AddBasicEntity() -> Entity
 end
-extern struct VisibilityState
+extern struct BVHNode
 end
 extern enum ViewFlags : uint32
     NONE = 0x0,
@@ -712,6 +414,91 @@ extern class View
     GetPriority() -> int
     SetPriority(priority : int) -> void
 end
+extern class Subsystem
+end
+extern enum SubsystemUpdatePhase : uint8
+    BeforeVis,
+    AfterVis
+end
+extern class EditorGizmoBase
+    GetNode() -> Node
+    IsDragging() -> bool
+    GetManipulationMode() -> EditorManipulationMode
+    GetPriority() -> int
+    GetMenuText() -> string
+end
+extern class NullEditorGizmo : EditorGizmoBase
+end
+extern class TranslateEditorGizmo : EditorGizmoBase
+end
+extern class RotateEditorGizmo : EditorGizmoBase
+end
+extern class VolumeEditorGizmo : EditorGizmoBase
+end
+extern class GenerateLightmapsEditorTask : TickableEditorTask
+    GetWorld() -> World
+    SetWorld(world : World) -> void
+    GetScene() -> Scene
+    SetScene(scene : Scene) -> void
+    Start() -> void
+    Cancel() -> void
+    IsCompleted() -> bool
+    Tick() -> void
+end
+extern enum EditorManipulationMode
+    NONE = 0,
+    TRANSLATE,
+    ROTATE,
+    SCALE,
+    VOLUME_EDIT
+end
+extern class EditorSubsystem : Subsystem
+    GetCurrentProject() -> EditorProject
+    GetActiveViewport() -> EditorViewport
+    SetActiveViewport(viewport : EditorViewport) -> void
+    AddViewport(viewport : EditorViewport) -> void
+    RemoveViewport(viewport : EditorViewport) -> void
+    GetEditorScene() -> Scene
+    ExecuteCommand(command : EditorCommandBase) -> bool
+    ExecuteCommandByName(name : Name, arguments : string) -> bool
+    NewProject() -> void
+    OpenProject(project : EditorProject) -> void
+    CloseProject() -> void
+    ShowImportContentDialog() -> void
+    SetFocusedNode(focusedNode : Node, shouldSelectInOutline : bool) -> void
+    GetFocusedNode() -> Node
+    GetActiveScene() -> Scene
+    SetActiveScene(scene : Scene) -> void
+    GetSelectedManipulationMode() -> EditorManipulationMode
+    SetSelectedManipulationMode(mode : EditorManipulationMode) -> void
+    GetSelectedGizmo() -> EditorGizmoBase
+    GetGizmo(mode : EditorManipulationMode) -> EditorGizmoBase
+    SetSelectedBucket(bucketIndex : uint32) -> void
+    CalculateSceneInsertionPoint(desiredDistance : float, offsetFromSurface : float) -> Vec3f
+    OnFocusedNodeChanged : any
+    OnProjectClosing : any
+    OnProjectOpened : any
+    OnActiveSceneChanged : any
+    OnSelectedGizmoChanged : any
+    OnSelectedBucketChanged : any
+    OnActiveViewportChanged : any
+    StartSimulation() -> void
+    StopSimulation() -> void
+    PauseSimulation() -> void
+end
+extern class BakerSubsystem : Subsystem
+end
+extern struct ComponentInfo
+    TypeId : TypeId
+    Access : ComponentAccess
+    ReceivesEvents : bool
+end
+extern enum ComponentAccess : uint32
+    NONE = 0,
+    READ = 0x1,
+    WRITE = 0x2,
+    READ_WRITE = (READ | WRITE)
+end
 extern class SystemBase
 end
 extern class ScriptableSystem : SystemBase
@@ -734,39 +521,22 @@ extern class ScriptableSystem : SystemBase
 end
 extern class DynamicSkySystem : SystemBase
 end
-extern class Subsystem
-end
-extern enum SubsystemUpdatePhase : uint8
-    BeforeVis,
-    AfterVis
-end
-extern class BakerSubsystem : Subsystem
-end
 extern struct TagComponentBase
     Value : EntityTag
 end
 extern struct EntityTag
     Value : uint64
 end
-extern class EntityManager
-    GetWorld() -> World
-    GetScene() -> Scene
-    AddExistingEntity(entity : Entity) -> void
-    AddTypedEntity(cls : Class) -> Entity
-    AddBasicEntity() -> Entity
+extern struct VisibilityStateSnapshot
 end
-extern struct ComponentInfo
-    TypeId : TypeId
-    Access : ComponentAccess
-    ReceivesEvents : bool
+extern struct VisibilityState
 end
-extern enum ComponentAccess : uint32
-    NONE = 0,
-    READ = 0x1,
-    WRITE = 0x2,
-    READ_WRITE = (READ | WRITE)
+extern class RigidBody
 end
-extern struct BVHNode
+extern struct PhysicsMaterial
+    Mass : float
+end
+extern class PhysicsWorldBase
 end
 extern enum VulkanDeviceQueueType : uint8
     INVALID = 0,
@@ -792,6 +562,90 @@ extern enum ShadowMapType : uint32
     SMT_DIRECTIONAL,
     SMT_SPOT,
     SMT_OMNI
+end
+extern struct MeshRayTracingData
+end
+extern struct DescriptorSetLayoutElement
+    Type : ShaderInputType
+    Binding : uint32
+    Count : uint32
+end
+extern enum GpuImageFlags : uint32
+    NONE = 0x0
+end
+extern struct MeshAttributes
+    InputLayout : VertexInputLayoutDesc
+    Topology : Topology
+    IndexBufferElemType : GpuElemType
+end
+extern struct MaterialAttributes
+    ShaderName : Name
+    ShaderProperties : ShaderPropertySet
+    Bucket : RenderBucket
+    FillMode : FillMode
+    BlendFunction : BlendFunction
+    CullFaces : FaceCullMode
+    Flags : MaterialAttributeFlags
+    StencilFunction : StencilFunction
+    StencilReference : uint8
+    DepthBias : int32
+    DepthBiasSlope : float
+end
+extern enum MaterialAttributeFlags : uint8
+    MAF_NONE = 0x0,
+    MAF_DEPTH_WRITE = 0x1,
+    MAF_DEPTH_TEST = 0x2,
+    MAF_DEPTH_BIAS = 0x4,
+    MAF_DEPTH_CLAMP = 0x8,
+    MAF_STENCIL_TEST = 0x10,
+    MAF_ALPHA_DISCARD = 0x20
+end
+extern struct RayTracingReflectionsConfig
+    Extent : Vec2u
+end
+extern enum GBufferTargetName : uint32
+    GTN_ALBEDO = 0,
+    GTN_NORMALS,
+    GTN_MATERIAL,
+    GTN_VELOCITY,
+    GTN_DEPTH,
+    GTN_MAX
+end
+extern struct MaterialTextures
+    Values : Array<Texture>
+end
+extern struct MaterialParameters
+    Albedo : Vec4f
+    Metalness : float
+    Roughness : float
+    AlphaThreshold : float
+    ParallaxHeightScale : float
+    Transmission : float
+    Ior : float
+    EmissiveColor : Color
+    EmissiveIntensity : float
+    UserParams : Vec4f
+end
+extern enum MaterialTextureKey : uint64
+    NONE = 0,
+    Diffuse = 0x1,
+    Normals = 0x2,
+    Parallax = 0x4,
+    Metalness = 0x8,
+    Roughness = 0x10,
+    AmbientOcclusion = 0x20
+end
+extern enum GlobalRendererType : uint32
+    GRT_NONE = ~0u,
+    GRT_MAIN = 0,
+    GRT_UI,
+    GRT_ENV_PROBE,
+    GRT_ENV_GRID,
+    GRT_SHADOW_MAP,
+    GRT_PARTICLE_VOLUME,
+    GRT_SPRITE,
+    GRT_SSAO,
+    GRT_MAX
 end
 extern enum VertexType : uint8
     VT_Invalid = 0x0,
@@ -1101,19 +955,9 @@ extern enum Topology : uint8
 end
 extern struct BlendFunction
 end
-extern struct MeshRayTracingData
-end
-extern enum GlobalRendererType : uint32
-    GRT_NONE = ~0u,
-    GRT_MAIN = 0,
-    GRT_UI,
-    GRT_ENV_PROBE,
-    GRT_ENV_GRID,
-    GRT_SHADOW_MAP,
-    GRT_PARTICLE_VOLUME,
-    GRT_SPRITE,
-    GRT_SSAO,
-    GRT_MAX
+extern enum AccelerationStructureType : uint8
+    BOTTOM_LEVEL,
+    TOP_LEVEL
 end
 extern enum RenderBucket : uint8
     Opaque,
@@ -1122,93 +966,225 @@ extern enum RenderBucket : uint8
     Sky,
     Debug
 end
-extern struct MeshAttributes
-    InputLayout : VertexInputLayoutDesc
-    Topology : Topology
-    IndexBufferElemType : GpuElemType
-end
-extern struct MaterialAttributes
-    ShaderName : Name
-    ShaderProperties : ShaderPropertySet
-    Bucket : RenderBucket
-    FillMode : FillMode
-    BlendFunction : BlendFunction
-    CullFaces : FaceCullMode
-    Flags : MaterialAttributeFlags
-    StencilFunction : StencilFunction
-    StencilReference : uint8
-    DepthBias : int32
-    DepthBiasSlope : float
-end
-extern enum MaterialAttributeFlags : uint8
-    MAF_NONE = 0x0,
-    MAF_DEPTH_WRITE = 0x1,
-    MAF_DEPTH_TEST = 0x2,
-    MAF_DEPTH_BIAS = 0x4,
-    MAF_DEPTH_CLAMP = 0x8,
-    MAF_STENCIL_TEST = 0x10,
-    MAF_ALPHA_DISCARD = 0x20
-end
-extern struct RayTracingReflectionsConfig
-    Extent : Vec2u
-end
-extern struct MaterialTextures
-    Values : Array<Texture>
-end
-extern struct MaterialParameters
-    Albedo : Vec4f
-    Metalness : float
-    Roughness : float
-    AlphaThreshold : float
-    ParallaxHeightScale : float
-    Transmission : float
-    Ior : float
-    EmissiveColor : Color
-    EmissiveIntensity : float
-    UserParams : Vec4f
-end
-extern enum MaterialTextureKey : uint64
-    NONE = 0,
-    Diffuse = 0x1,
-    Normals = 0x2,
-    Parallax = 0x4,
-    Metalness = 0x8,
-    Roughness = 0x10,
-    AmbientOcclusion = 0x20
-end
-extern enum GpuImageFlags : uint32
-    NONE = 0x0
-end
-extern enum GBufferTargetName : uint32
-    GTN_ALBEDO = 0,
-    GTN_NORMALS,
-    GTN_MATERIAL,
-    GTN_VELOCITY,
-    GTN_DEPTH,
-    GTN_MAX
-end
 extern class UISubsystem : Subsystem
     AddDebugOverlay(debugOverlay : OverlayBase) -> void
     RemoveDebugOverlay(debugOverlay : OverlayBase) -> bool
 end
-extern struct DescriptorSetLayoutElement
-    Type : ShaderInputType
-    Binding : uint32
-    Count : uint32
-end
 extern struct DebugDrawerConfig
     Enabled : bool
 end
-extern enum AccelerationStructureType : uint8
-    BOTTOM_LEVEL,
-    TOP_LEVEL
+extern class AudioManager
 end
-extern class RigidBody
+extern enum AudioSourceState : uint32
+    UNDEFINED,
+    STOPPED,
+    PLAYING,
+    PAUSED
 end
-extern class PhysicsWorldBase
+extern enum AudioSourceFormat : uint32
+    MONO8,
+    MONO16,
+    STEREO8,
+    STEREO16
 end
-extern struct PhysicsMaterial
-    Mass : float
+extern class AudioSource
+    GetFormat() -> AudioSourceFormat
+    SetFormat(format : AudioSourceFormat) -> void
+    GetFreq() -> uint64
+    SetFreq(freq : uint64) -> void
+    GetData() -> ByteBuffer
+    SetData(data : ByteBuffer) -> void
+    GetSampleLength() -> uint32
+    SetSampleLength(sampleLength : uint32) -> void
+    GetDuration() -> double
+    SetDuration(duration : double) -> void
+end
+extern class ApplicationWindow
+    GetInputManager() -> InputManager
+    GetHWND() -> any
+    GetSize() -> Vec2i
+    SetMousePosition(position : Vec2i) -> void
+    GetMousePosition() -> Vec2i
+    SetIsMouseLocked(locked : bool) -> void
+    IsMouseLocked() -> bool
+    HasMouseFocus() -> bool
+    IsHighDPI() -> bool
+    GetDimensions() -> Vec2i
+    Close() -> void
+    OnWindowSizeChanged : any
+    OnClose : any
+end
+extern class AndroidApplicationWindow : ApplicationWindow
+    SetMousePosition(position : Vec2i) -> void
+    GetMousePosition() -> Vec2i
+    GetDimensions() -> Vec2i
+    SetIsMouseLocked(locked : bool) -> void
+    IsMouseLocked() -> bool
+    HasMouseFocus() -> bool
+    Close() -> void
+end
+extern class SDLApplicationWindow : ApplicationWindow
+    SetMousePosition(position : Vec2i) -> void
+    GetMousePosition() -> Vec2i
+    GetDimensions() -> Vec2i
+    SetIsMouseLocked(locked : bool) -> void
+    IsMouseLocked() -> bool
+    HasMouseFocus() -> bool
+    IsHighDPI() -> bool
+    Close() -> void
+end
+extern class CocoaApplicationWindow : ApplicationWindow
+    SetMousePosition(position : Vec2i) -> void
+    GetMousePosition() -> Vec2i
+    GetDimensions() -> Vec2i
+    SetIsMouseLocked(locked : bool) -> void
+    IsMouseLocked() -> bool
+    HasMouseFocus() -> bool
+    IsHighDPI() -> bool
+    GetNSWindow() -> any
+    GetNSView() -> any
+    Close() -> void
+end
+extern class Win32ApplicationWindow : ApplicationWindow
+    SetMousePosition(position : Vec2i) -> void
+    GetMousePosition() -> Vec2i
+    GetDimensions() -> Vec2i
+    SetIsMouseLocked(locked : bool) -> void
+    IsMouseLocked() -> bool
+    HasMouseFocus() -> bool
+    Close() -> void
+end
+extern class AppContextBase
+    static GetInstance() -> AppContextBase
+    GetAppName() -> string
+    GetMainWindow() -> ApplicationWindow
+    SetMainWindow(window : ApplicationWindow) -> void
+    GetWindows() -> Array<ApplicationWindow>
+    CreateSystemWindow(windowOptions : WindowOptions) -> ApplicationWindow
+    RemoveWindow(window : ApplicationWindow) -> void
+    RunCommandlet(commandletName : string, args : CommandLineArguments) -> Result
+    OnCurrentWindowChanged : any
+end
+extern class Win32AppContext : AppContextBase
+    CreateSystemWindow(windowOptions : WindowOptions) -> ApplicationWindow
+end
+extern class AndroidAppContext : AppContextBase
+    CreateSystemWindow(windowOptions : WindowOptions) -> ApplicationWindow
+end
+extern class SDLAppContext : AppContextBase
+    CreateSystemWindow(windowOptions : WindowOptions) -> ApplicationWindow
+end
+extern class CocoaAppContext : AppContextBase
+    CreateSystemWindow(windowOptions : WindowOptions) -> ApplicationWindow
+end
+extern struct WindowOptions
+end
+extern enum WindowFlags : uint32
+    NONE = 0x0,
+    HEADLESS = 0x1,
+    NO_GFX = 0x2,
+    HIGH_DPI = 0x4,
+    EVENTS_POLLING = 0x8
+end
+extern class StreamingVolumeBase
+    GetShape() -> StreamingVolumeShape
+    GetBoundingBox(outAabb : BoundingBox) -> bool
+    GetBoundingSphere(outSphere : BoundingSphere) -> bool
+    ContainsPoint(point : Vec3f) -> bool
+    GetShape_Impl() -> StreamingVolumeShape
+    GetBoundingBox_Impl(outAabb : BoundingBox) -> bool
+    GetBoundingSphere_Impl(outSphere : BoundingSphere) -> bool
+    ContainsPoint_Impl(point : Vec3f) -> bool
+    NotifyUpdate() -> void
+end
+extern enum StreamingVolumeShape : uint32
+    SPHERE = 0,
+    BOX,
+    MAX,
+    INVALID = ~0u
+end
+extern class StreamingManager
+    AddStreamingVolume(volume : StreamingVolumeBase) -> void
+    RemoveStreamingVolume(volume : StreamingVolumeBase) -> void
+end
+extern class StreamableBase
+    GetBoundingBox() -> BoundingBox
+    OnStreamStart() -> void
+    OnLoaded() -> void
+    OnRemoved() -> void
+    GetBoundingBox_Impl() -> BoundingBox
+    OnStreamStart_Impl() -> void
+    OnLoaded_Impl() -> void
+    OnRemoved_Impl() -> void
+end
+extern enum StreamingCellState : uint32
+    INVALID = ~0u,
+    UNLOADED = 0,
+    UNLOADING,
+    WAITING,
+    LOADING,
+    LOADED,
+    MAX
+end
+extern class StreamingCell : StreamableBase
+    GetPatchInfo() -> StreamingCellInfo
+    Update(delta : float) -> void
+    GetBoundingBox_Impl() -> BoundingBox
+    Update_Impl(delta : float) -> void
+end
+extern struct StreamingCellInfo
+    Coord : Vec2i
+    Extent : Vec3u
+    Scale : Vec3f
+    Bounds : BoundingBox
+end
+extern struct StreamingCellNeighbor
+    Coord : Vec2i
+end
+extern class TerrainStreamingCell : StreamingCell
+    OnStreamStart_Impl() -> void
+    OnLoaded_Impl() -> void
+    OnRemoved_Impl() -> void
+end
+extern class BakerBase
+end
+extern enum LightmapShadingType : uint32
+    IRRADIANCE = 0,
+    RADIANCE,
+    FULL,
+    SHADOW,
+    MAX
+end
+extern struct BakerConfig
+    NumSamples : uint32
+    MaxTexelsPerFrame : uint32
+    OnlyGenerateUVs : bool
+end
+extern class InputHandlerBase
+    OnKeyDown(evt : KeyboardEvent) -> bool
+    OnKeyUp(evt : KeyboardEvent) -> bool
+    OnMouseDown(evt : MouseEvent) -> bool
+    OnMouseUp(evt : MouseEvent) -> bool
+    OnMouseMove(evt : MouseEvent) -> bool
+    OnMouseDrag(evt : MouseEvent) -> bool
+    OnMouseLeave(evt : MouseEvent) -> bool
+    OnClick(evt : MouseEvent) -> bool
+    OnGainFocus(evt : MouseEvent) -> bool
+    OnLoseFocus(evt : MouseEvent) -> bool
+    OnKeyDown_Impl(evt : KeyboardEvent) -> bool
+    OnKeyUp_Impl(evt : KeyboardEvent) -> bool
+    OnMouseDown_Impl(evt : MouseEvent) -> bool
+    OnMouseUp_Impl(evt : MouseEvent) -> bool
+    OnMouseMove_Impl(evt : MouseEvent) -> bool
+    OnMouseDrag_Impl(evt : MouseEvent) -> bool
+    OnMouseLeave_Impl(evt : MouseEvent) -> bool
+    OnClick_Impl(evt : MouseEvent) -> bool
+    OnGainFocus_Impl(evt : MouseEvent) -> bool
+    OnLoseFocus_Impl(evt : MouseEvent) -> bool
+end
+extern class NullInputHandler : InputHandlerBase
+end
+extern class CharacterControllerInputHandler : InputHandlerBase
 end
 extern enum MouseButtonKey : uint32
     MBK_INVALID = ~0u,
@@ -1231,6 +1207,24 @@ extern enum MouseButtonState : uint32
     LEFT = 0x1,
     MIDDLE = 0x2,
     RIGHT = 0x4
+end
+extern class InputManager
+    IsMouseLocked() -> bool
+    PushMouseLockState(mouseLocked : bool, syncToVirtualPosition : bool) -> void
+    PopMouseLockState() -> void
+    GetMousePosition() -> Vec2i
+    GetVirtualMousePosition() -> Vec2i
+    GetPreviousVirtualMousePosition() -> Vec2i
+    GetWindowSize() -> Vec2i
+    IsKeyDown(key : KeyCode) -> bool
+    IsKeyUp(key : KeyCode) -> bool
+    IsShiftDown() -> bool
+    IsAltDown() -> bool
+    IsCtrlDown() -> bool
+    IsButtonDown(btn : MouseButtonKey) -> bool
+    GetButtonStates() -> MouseButtonState
+    IsButtonUp(btn : MouseButtonKey) -> bool
+    GetWindow() -> ApplicationWindow
 end
 extern struct KeyboardEvent
     InputManager : InputManager
@@ -1307,50 +1301,6 @@ extern enum KeyCode : uint16
     KEY_UP = 82,
     KEY_ESCAPE = 27
 end
-extern class InputManager
-    IsMouseLocked() -> bool
-    PushMouseLockState(mouseLocked : bool, syncToVirtualPosition : bool) -> void
-    PopMouseLockState() -> void
-    GetMousePosition() -> Vec2i
-    GetVirtualMousePosition() -> Vec2i
-    GetPreviousVirtualMousePosition() -> Vec2i
-    GetWindowSize() -> Vec2i
-    IsKeyDown(key : KeyCode) -> bool
-    IsKeyUp(key : KeyCode) -> bool
-    IsShiftDown() -> bool
-    IsAltDown() -> bool
-    IsCtrlDown() -> bool
-    IsButtonDown(btn : MouseButtonKey) -> bool
-    GetButtonStates() -> MouseButtonState
-    IsButtonUp(btn : MouseButtonKey) -> bool
-    GetWindow() -> ApplicationWindow
-end
-extern class InputHandlerBase
-    OnKeyDown(evt : KeyboardEvent) -> bool
-    OnKeyUp(evt : KeyboardEvent) -> bool
-    OnMouseDown(evt : MouseEvent) -> bool
-    OnMouseUp(evt : MouseEvent) -> bool
-    OnMouseMove(evt : MouseEvent) -> bool
-    OnMouseDrag(evt : MouseEvent) -> bool
-    OnMouseLeave(evt : MouseEvent) -> bool
-    OnClick(evt : MouseEvent) -> bool
-    OnGainFocus(evt : MouseEvent) -> bool
-    OnLoseFocus(evt : MouseEvent) -> bool
-    OnKeyDown_Impl(evt : KeyboardEvent) -> bool
-    OnKeyUp_Impl(evt : KeyboardEvent) -> bool
-    OnMouseDown_Impl(evt : MouseEvent) -> bool
-    OnMouseUp_Impl(evt : MouseEvent) -> bool
-    OnMouseMove_Impl(evt : MouseEvent) -> bool
-    OnMouseDrag_Impl(evt : MouseEvent) -> bool
-    OnMouseLeave_Impl(evt : MouseEvent) -> bool
-    OnClick_Impl(evt : MouseEvent) -> bool
-    OnGainFocus_Impl(evt : MouseEvent) -> bool
-    OnLoseFocus_Impl(evt : MouseEvent) -> bool
-end
-extern class NullInputHandler : InputHandlerBase
-end
-extern class CharacterControllerInputHandler : InputHandlerBase
-end
 extern enum EventType : uint32
     INVALID = ~0u,
     WINDOW_EVENT = 0x0200,
@@ -1373,357 +1323,9 @@ extern enum EventFlags : uint8
     NONE = 0x0,
     RELATIVE_MOUSE = 0x1
 end
-extern class CommandletBase
-    static GetArgumentDefinitions() -> CommandLineArgumentDefinitions
-    Run(args : CommandLineArguments) -> Result
-    Run_Impl(args : CommandLineArguments) -> Result
+extern struct OctantId
 end
-extern enum GameStateMode : uint32
-    STOPPED = 0,
-    SIMULATING,
-    PAUSED,
-    EDIT_MODE
-end
-extern struct GameState
-    Mode : GameStateMode
-    DeltaTime : float
-    GameTime : float
-    IsStopped() -> bool
-    IsSimulating() -> bool
-    IsPaused() -> bool
-    IsEditMode() -> bool
-end
-extern class Game
-    GetAssetRegistry() -> AssetRegistry
-    SetAssetRegistry(assetRegistry : AssetRegistry) -> void
-    GetWorld() -> World
-    SetWorld(world : World) -> void
-    GetGameState() -> GameState
-    OnLaunch() -> void
-    OnUpdate(delta : float) -> void
-    Initialize() -> void
-    Shutdown() -> void
-    SetToEditMode() -> void
-    IsLaunched() -> bool
-    StartSimulating() -> void
-    StopSimulating() -> void
-    PauseSimulation() -> void
-    OnLaunched : any
-    OnGameStateChange : any
-    OnLaunch_Impl() -> void
-    OnUpdate_Impl(delta : float) -> void
-    World : World
-    GameState : GameState
-end
-extern class EngineStats
-    static GetInstance() -> EngineStats
-    GetFps() -> double
-    GetMsPerFrame() -> double
-    QueryStatValue(path : string, valueIfNotFound : double) -> double
-end
-extern enum EnginePoolName : int
-    EPN_INVALID = -1,
-    EPN_CORE = 0,
-    EPN_RENDER,
-    EPN_SCENE,
-    EPN_MAX
-end
-extern class EngineDriver
-    static GetInstance() -> EngineDriver
-    GetCurrentWorld() -> World
-    SetCurrentWorld(world : World) -> void
-    GetDefaultWorld() -> World
-    SetDefaultWorld(defaultWorld : World) -> void
-    SetGameInstance(gameInstance : Game) -> void
-    GetGameInstance() -> Game
-end
-extern enum GpuType : uint8
-    Unknown = 0,
-    Integrated,
-    Dedicated
-end
-extern class DeviceDetails
-    GetGpuType() -> GpuType
-    GetGpuVendor() -> GpuVendor
-    GetGpuModel() -> string
-    GetGpuVendorName() -> string
-    GetDriverVersion() -> string
-    IsDiscreteGpu() -> bool
-    SupportsRayTracing() -> bool
-    SupportsRayQueries() -> bool
-    SupportsVariableRateShading() -> bool
-    SupportsSamplerFeedback() -> bool
-    SupportsBindless() -> bool
-end
-extern enum GpuVendor : uint8
-    Unknown = 0,
-    Nvidia,
-    Amd,
-    Intel,
-    Qualcomm,
-    Apple,
-    Microsoft
-end
-extern class EditorViewport
-    GetCamera() -> Camera
-    GetView() -> View
-    GetWindow() -> ApplicationWindow
-    CreateViewportWindow(options : WindowOptions) -> ApplicationWindow
-end
-extern class EditorTaskBase
-    GetTitle() -> string
-    GetDescription() -> string
-    SetDescription(description : string) -> void
-    GetProgress() -> float
-    SetProgress(progress : float) -> void
-    IsCancellationRequested() -> bool
-    IsCommitted() -> bool
-    Start() -> void
-    Cancel() -> void
-    IsCompleted() -> bool
-    Commit() -> bool
-    OnComplete : any
-    OnCancel : any
-    OnDescriptionChange : any
-end
-extern class TickableEditorTask : EditorTaskBase
-    IsForegroundTask() -> bool
-    SetIsForegroundTask(isForeground : bool) -> void
-    Start() -> void
-    Cancel() -> void
-    IsCompleted() -> bool
-    Commit() -> bool
-    Tick() -> void
-    Start_Impl() -> void
-    Cancel_Impl() -> void
-    IsCompleted_Impl() -> bool
-    Tick_Impl() -> void
-end
-extern class LongRunningEditorTask : EditorTaskBase
-    Start() -> void
-    Cancel() -> void
-    IsCompleted() -> bool
-    Process() -> void
-    Commit() -> bool
-    Start_Impl() -> void
-    Cancel_Impl() -> void
-    IsCompleted_Impl() -> bool
-    Process_Impl() -> void
-end
-extern class EditorGizmoBase
-    GetNode() -> Node
-    IsDragging() -> bool
-    GetManipulationMode() -> EditorManipulationMode
-    GetPriority() -> int
-    GetMenuText() -> string
-end
-extern class NullEditorGizmo : EditorGizmoBase
-end
-extern class TranslateEditorGizmo : EditorGizmoBase
-end
-extern class RotateEditorGizmo : EditorGizmoBase
-end
-extern class VolumeEditorGizmo : EditorGizmoBase
-end
-extern class GenerateLightmapsEditorTask : TickableEditorTask
-    GetWorld() -> World
-    SetWorld(world : World) -> void
-    GetScene() -> Scene
-    SetScene(scene : Scene) -> void
-    Start() -> void
-    Cancel() -> void
-    IsCompleted() -> bool
-    Tick() -> void
-end
-extern enum EditorManipulationMode
-    NONE = 0,
-    TRANSLATE,
-    ROTATE,
-    SCALE,
-    VOLUME_EDIT
-end
-extern class EditorSubsystem : Subsystem
-    GetCurrentProject() -> EditorProject
-    GetActiveViewport() -> EditorViewport
-    SetActiveViewport(viewport : EditorViewport) -> void
-    AddViewport(viewport : EditorViewport) -> void
-    RemoveViewport(viewport : EditorViewport) -> void
-    GetEditorScene() -> Scene
-    ExecuteCommand(command : EditorCommandBase) -> bool
-    ExecuteCommandByName(name : Name, arguments : string) -> bool
-    NewProject() -> void
-    OpenProject(project : EditorProject) -> void
-    CloseProject() -> void
-    ShowImportContentDialog() -> void
-    SetFocusedNode(focusedNode : Node, shouldSelectInOutline : bool) -> void
-    GetFocusedNode() -> Node
-    GetActiveScene() -> Scene
-    SetActiveScene(scene : Scene) -> void
-    GetSelectedManipulationMode() -> EditorManipulationMode
-    SetSelectedManipulationMode(mode : EditorManipulationMode) -> void
-    GetSelectedGizmo() -> EditorGizmoBase
-    GetGizmo(mode : EditorManipulationMode) -> EditorGizmoBase
-    SetSelectedBucket(bucketIndex : uint32) -> void
-    CalculateSceneInsertionPoint(desiredDistance : float, offsetFromSurface : float) -> Vec3f
-    OnFocusedNodeChanged : any
-    OnProjectClosing : any
-    OnProjectOpened : any
-    OnActiveSceneChanged : any
-    OnSelectedGizmoChanged : any
-    OnSelectedBucketChanged : any
-    OnActiveViewportChanged : any
-    StartSimulation() -> void
-    StopSimulation() -> void
-    PauseSimulation() -> void
-end
-extern class EditorState
-    static GetInstance() -> EditorState
-    GetCurrentProject() -> EditorProject
-    SetCurrentProject(project : EditorProject) -> void
-    AddTask(task : EditorTaskBase) -> void
-    OnCurrentProjectChanged : any
-    OnTaskStarted : any
-    OnTaskEnded : any
-    OnTaskProgressUpdated : any
-end
-extern class EditorProject
-    GetName() -> Name
-    SetName(name : Name) -> void
-    GetWorld() -> World
-    GetGame() -> Game
-    SetGame(gameInstance : Game) -> void
-    GetLastSavedTime() -> Time
-    GetFilePath() -> string
-    AddScene(scene : Scene) -> void
-    RemoveScene(scene : Scene) -> void
-    GetProjectsDirectory() -> string
-    IsSaved() -> bool
-    Save() -> Result
-    SaveAs(filepath : string) -> Result
-    GetActionStack() -> EditorActionStack
-    Close() -> void
-    OnProjectSaved : any
-    Name : Name
-    LastSavedTime : Time
-    Filepath : string
-    GameInstance : Game
-    ActionStack : EditorActionStack
-end
-extern class EditorCommandBase
-    GetText() -> string
-    GetArguments() -> Array<string>
-    SetArguments(args : Array<string>) -> void
-    NumArguments() -> int
-    GetArgument(index : int) -> string
-end
-extern enum EditorActionStackState : uint32
-    NONE = 0x0,
-    CAN_UNDO = 0x1,
-    CAN_REDO = 0x2
-end
-extern class EditorActionStack
-    PushAction(action : EditorActionBase) -> bool
-    CanUndo() -> bool
-    CanRedo() -> bool
-    Undo() -> void
-    Redo() -> void
-    GetUndoAction() -> EditorActionBase
-    GetRedoAction() -> EditorActionBase
-    OnBeforeActionPush : any
-    OnBeforeActionPop : any
-    OnAfterActionPush : any
-    OnAfterActionPop : any
-    OnStateChange : any
-end
-extern class EditorActionBase
-    GetText() -> string
-    Execute(editorSubsystem : EditorSubsystem, project : EditorProject) -> void
-    Revert(editorSubsystem : EditorSubsystem, project : EditorProject) -> void
-end
-extern class FunctionalEditorAction : EditorActionBase
-    GetText() -> string
-    Execute(editorSubsystem : EditorSubsystem, project : EditorProject) -> void
-    Revert(editorSubsystem : EditorSubsystem, project : EditorProject) -> void
-end
-extern class BakerBase
-end
-extern enum LightmapShadingType : uint32
-    IRRADIANCE = 0,
-    RADIANCE,
-    FULL,
-    SHADOW,
-    MAX
-end
-extern struct BakerConfig
-    NumSamples : uint32
-    MaxTexelsPerFrame : uint32
-    OnlyGenerateUVs : bool
-end
-extern enum AudioSourceState : uint32
-    UNDEFINED,
-    STOPPED,
-    PLAYING,
-    PAUSED
-end
-extern enum AudioSourceFormat : uint32
-    MONO8,
-    MONO16,
-    STEREO8,
-    STEREO16
-end
-extern class AudioSource
-    GetFormat() -> AudioSourceFormat
-    SetFormat(format : AudioSourceFormat) -> void
-    GetFreq() -> uint64
-    SetFreq(freq : uint64) -> void
-    GetData() -> ByteBuffer
-    SetData(data : ByteBuffer) -> void
-    GetSampleLength() -> uint32
-    SetSampleLength(sampleLength : uint32) -> void
-    GetDuration() -> double
-    SetDuration(duration : double) -> void
-end
-extern class AudioManager
-end
-extern struct BlobDataReference
-    Key : Name
-    Size : uint64
-    Raw : any
-    ReadOnly : bool
-end
-extern class BlobStorage
-    BaseDirectory : string
-    PageSize : uint64
-    FreeRanges : Array<BlobMappingRange>
-    PageData : Array<BlobPageData>
-end
-extern struct BlobPageData
-    Cursor : uint64
-end
-extern struct BlobMappingRange
-    Start : uint32
-    End : uint32
-end
-extern enum AddAssetConflictMode : uint8
-    FailOnConflict = 0,
-    GenerateNewName,
-    ReplaceExisting,
-    Default
-end
-extern struct AssetDesc
-    Name : Name
-    Index : uint32
-end
-extern enum AssetObjectFlags : uint8
-    None = 0x0,
-    Persistent = 0x1,
-    Transient = 0x2
-end
-extern enum AssetPackageFlags : uint32
-    None = 0x0,
-    Transient = 0x1,
-    Hidden = 0x2,
-    SaveOnChanged = 0x4
+extern struct AssetBucket
 end
 extern class AssetCollector
     GetBasePath() -> string
@@ -1752,13 +1354,26 @@ extern enum AssetChangeType : uint32
     RENAMED = 3,
     MAX
 end
-extern class AssetRegistry
-    GetRootPath() -> string
-    SetRootPath(rootPath : string) -> void
+extern enum AddAssetConflictMode : uint8
+    FailOnConflict = 0,
+    GenerateNewName,
+    ReplaceExisting,
+    Default
 end
-extern struct AssetReference
-    GetAssetPath() -> AssetPath
-    SetAssetPath(assetPath : AssetPath) -> void
+extern struct AssetDesc
+    Name : Name
+    Index : uint32
+end
+extern enum AssetObjectFlags : uint8
+    None = 0x0,
+    Persistent = 0x1,
+    Transient = 0x2
+end
+extern enum AssetPackageFlags : uint32
+    None = 0x0,
+    Transient = 0x1,
+    Hidden = 0x2,
+    SaveOnChanged = 0x4
 end
 extern struct AssetPath
     IsValid() -> bool
@@ -1795,18 +1410,6 @@ extern class AssetObject
     AssetIndex : uint32
     AssetPath : AssetPath
 end
-extern struct FontAtlasTextureSet
-    MainAtlas : Texture
-    Atlases : Array<any>
-end
-extern class FontAtlas : AssetObject
-    AtlasTextures : FontAtlasTextureSet
-    CellDimensions : Vec2i
-    GlyphMetrics : Array<GlyphMetrics>
-    SymbolList : Array<uint32>
-end
-extern class ScriptAsset : AssetObject
-end
 extern class Skeleton : AssetObject
     GetRootBone() -> Bone
     SetRootBone(bone : Bone) -> void
@@ -1832,67 +1435,6 @@ extern class AnimationTrack : AssetObject
     GetKeyframe(time : float) -> Keyframe
     BoneName : Name
     KeyframeData : BlobDataReference
-end
-extern struct CSMState
-    PlayerCenter : Vec3f
-end
-extern struct FogParams
-    Color : Color
-    StartDistance : float
-    EndDistance : float
-end
-extern enum WorldFlags : uint32
-    NONE = 0x0,
-    EDITOR_WORLD = 0x1,
-    HAS_PHYSICS = 0x2,
-    HAS_STREAMING = 0x4,
-    HAS_SCENE_STREAMING_LAYER = 0x100,
-    ALL_STREAMING_LAYER_FLAGS = HAS_SCENE_STREAMING_LAYER,
-    DEFAULT = ((HAS_PHYSICS | HAS_STREAMING) | ALL_STREAMING_LAYER_FLAGS)
-end
-extern struct CSMParams
-    NumCascades : uint32
-end
-extern class World : AssetObject
-    GetGame() -> Game
-    GetWorldFlags() -> WorldFlags
-    SetWorldFlags(flags : WorldFlags) -> void
-    GetFogParams() -> FogParams
-    SetFogParams(fogParams : FogParams) -> void
-    GetCSMParams() -> CSMParams
-    SetCSMParams(csmParams : CSMParams) -> void
-    GetCSMState() -> CSMState
-    SetCSMState(csmState : CSMState) -> void
-    GetPhysicsWorld() -> PhysicsWorldBase
-    TryAddSubsystem(subsystem : Subsystem) -> bool
-    GetSubsystemByName(name : any) -> Subsystem
-    RemoveSubsystem(subsystem : Subsystem) -> bool
-    GetWorldGrid() -> WorldGrid
-    GetGameState() -> GameState
-    AddScene(scene : Scene, addToStreamingLayer : bool) -> void
-    RemoveScene(scene : Scene, removeFromStreamingLayer : bool) -> bool
-    HasScene(sceneId : any) -> bool
-    GetSceneByName(nameHash : any) -> Scene
-    GetScenes() -> Array<Scene>
-    AddView(view : View) -> void
-    RemoveView(view : View) -> void
-    AddSystem(system : SystemBase) -> SystemBase
-    RemoveSystem(system : SystemBase) -> bool
-    OnSceneAdded : any
-    OnSceneRemoved : any
-    DeserializeNonStreamingScenes(scenes : Array<Scene>) -> void
-    SerializeNonStreamingScenes() -> Array<Scene>
-    DeserializeStreamingLayers(streamingLayers : Array<WGLayerDesc>) -> void
-    SerializeStreamingLayers() -> Array<WGLayerDesc>
-    DeserializeSystems(systems : Array<SystemBase>) -> void
-    SerializeSystems() -> Array<SystemBase>
-    GameInstance : Game
-    WorldFlags : WorldFlags
-    Scenes : Array<Scene>
-    FogParams : FogParams
-    CsmParams : CSMParams
-    CsmState : CSMState
-    Systems : Array<SystemBase>
 end
 extern enum SceneFlags : uint32
     NONE = 0x0,
@@ -2027,8 +1569,6 @@ extern class Bone : Node
     WorldBoneRotation : Quat4f
     InvBindingRotation : Quat4f
 end
-extern class InstancedMeshProxy : Node
-end
 extern class Entity : Node
     GetEntityManager() -> EntityManager
     ReceivesUpdate() -> bool
@@ -2115,6 +1655,10 @@ extern enum CameraProjectionMode : uint32
     PERSPECTIVE = 1,
     ORTHOGRAPHIC = 2
 end
+extern class OrthoCameraController : CameraController
+end
+extern class UICameraController : OrthoCameraController
+end
 extern class PerspectiveCameraController : CameraController
 end
 extern class FollowCameraController : PerspectiveCameraController
@@ -2141,96 +1685,7 @@ extern class EditorCameraInputHandler : InputHandlerBase
 end
 extern class CameraTrackController : PerspectiveCameraController
 end
-extern class OrthoCameraController : CameraController
-end
-extern class UICameraController : OrthoCameraController
-end
-extern class VolumeBase : Entity
-end
-extern struct ParticleVolumeParams
-    Texture : Texture
-    MaxParticles : uint32
-    Origin : Vec3f
-    StartSize : float
-    Radius : float
-    Randomness : float
-    Lifespan : float
-    HasPhysics : bool
-end
-extern class ParticleVolume : VolumeBase
-    GetParams() -> ParticleVolumeParams
-    SetParams(newParams : ParticleVolumeParams) -> void
-    Params : ParticleVolumeParams
-end
-extern class LightmapVolume : VolumeBase
-    Rebake() -> void
-    RadianceAtlasTextures : Array<Texture>
-    IrradianceAtlasTextures : Array<Texture>
-    Atlases : Array<LightmapVolumeAtlas>
-end
-extern struct LightmapVolumeAtlas
-end
-extern class FogVolume : VolumeBase
-    GetVolumeTexture() -> Texture
-    SetTextures(volumeTexture : Texture, noiseTexture : Texture) -> void
-    Rebake() -> void
-    VolumeTexture : Texture
-    NoiseTexture : Texture
-end
-extern struct EnvProbeSphericalHarmonics
-end
-extern class EnvProbe : VolumeBase
-    GetEnvProbeType() -> EnvProbeType
-    GetEnvProbeFlags() -> EnvProbeFlags
-    SetEnvProbeFlags(envProbeFlags : EnvProbeFlags) -> void
-    IsReflectionProbe() -> bool
-    IsSkyProbe() -> bool
-    IsAmbientProbe() -> bool
-    IsBaked() -> bool
-    SetIsBaked(isBaked : bool) -> void
-    IsRealtime() -> bool
-    GetOrigin() -> Vec3f
-    SetOrigin(origin : Vec3f) -> void
-    GetCamera() -> Camera
-    GetBakedTexture() -> Texture
-    SetBakedTexture(texture : Texture) -> void
-    Dimensions : Vec2u
-    EnvProbeType : EnvProbeType
-    EnvProbeFlags : EnvProbeFlags
-    ShData : EnvProbeSphericalHarmonics
-end
-extern class SkyProbe : EnvProbe
-    GetSkyboxCubemap() -> Texture
-end
-extern class ReflectionProbe : EnvProbe
-    BakeCubemap() -> void
-end
-extern enum EnvProbeType : uint32
-    EPT_INVALID = ~0u,
-    EPT_SKY = 0,
-    EPT_REFLECTION,
-    EPT_AMBIENT,
-    EPT_MAX
-end
-extern enum EnvProbeFlags : uint32
-    EPF_NONE = 0x0,
-    EPF_PARALLAX_CORRECTED = 0x1,
-    EPF_BAKED = 0x2
-end
-extern class Sprite : Entity
-end
-extern enum SpriteType : uint32
-    None = 0,
-    Point2D,
-    Spot3D,
-    Crosshair,
-    EnvProbe,
-    LightmapVolume,
-    Camera,
-    Text,
-    Max
-end
-extern class TextSprite : Sprite
+extern class EnvGrid : Entity
 end
 extern class Light : Entity
     GetLightType() -> LightType
@@ -2296,7 +1751,179 @@ extern enum LightFlags : uint32
     BakeStaticShadows = 0x20,
     Default = (ShadowCaster | ShadowPCF)
 end
-extern class EnvGrid : Entity
+extern class Sprite : Entity
+end
+extern enum SpriteType : uint32
+    None = 0,
+    Point2D,
+    Spot3D,
+    Crosshair,
+    EnvProbe,
+    LightmapVolume,
+    Camera,
+    Text,
+    Max
+end
+extern class TextSprite : Sprite
+end
+extern class VolumeBase : Entity
+end
+extern struct ParticleVolumeParams
+    Texture : Texture
+    MaxParticles : uint32
+    Origin : Vec3f
+    StartSize : float
+    Radius : float
+    Randomness : float
+    Lifespan : float
+    HasPhysics : bool
+end
+extern class ParticleVolume : VolumeBase
+    GetParams() -> ParticleVolumeParams
+    SetParams(newParams : ParticleVolumeParams) -> void
+    Params : ParticleVolumeParams
+end
+extern class FogVolume : VolumeBase
+    GetVolumeTexture() -> Texture
+    SetTextures(volumeTexture : Texture, noiseTexture : Texture) -> void
+    Rebake() -> void
+    VolumeTexture : Texture
+    NoiseTexture : Texture
+end
+extern class LightmapVolume : VolumeBase
+    Rebake() -> void
+    RadianceAtlasTextures : Array<Texture>
+    IrradianceAtlasTextures : Array<Texture>
+    Atlases : Array<LightmapVolumeAtlas>
+end
+extern struct LightmapVolumeAtlas
+end
+extern struct EnvProbeSphericalHarmonics
+end
+extern class EnvProbe : VolumeBase
+    GetEnvProbeType() -> EnvProbeType
+    GetEnvProbeFlags() -> EnvProbeFlags
+    SetEnvProbeFlags(envProbeFlags : EnvProbeFlags) -> void
+    IsReflectionProbe() -> bool
+    IsSkyProbe() -> bool
+    IsAmbientProbe() -> bool
+    IsBaked() -> bool
+    SetIsBaked(isBaked : bool) -> void
+    IsRealtime() -> bool
+    GetOrigin() -> Vec3f
+    SetOrigin(origin : Vec3f) -> void
+    GetCamera() -> Camera
+    GetBakedTexture() -> Texture
+    SetBakedTexture(texture : Texture) -> void
+    Dimensions : Vec2u
+    EnvProbeType : EnvProbeType
+    EnvProbeFlags : EnvProbeFlags
+    ShData : EnvProbeSphericalHarmonics
+end
+extern class SkyProbe : EnvProbe
+    GetSkyboxCubemap() -> Texture
+end
+extern class ReflectionProbe : EnvProbe
+    BakeCubemap() -> void
+end
+extern enum EnvProbeType : uint32
+    EPT_INVALID = ~0u,
+    EPT_SKY = 0,
+    EPT_REFLECTION,
+    EPT_AMBIENT,
+    EPT_MAX
+end
+extern enum EnvProbeFlags : uint32
+    EPF_NONE = 0x0,
+    EPF_PARALLAX_CORRECTED = 0x1,
+    EPF_BAKED = 0x2
+end
+extern class InstancedMeshProxy : Node
+end
+extern struct CSMState
+    PlayerCenter : Vec3f
+end
+extern struct FogParams
+    Color : Color
+    StartDistance : float
+    EndDistance : float
+end
+extern enum WorldFlags : uint32
+    NONE = 0x0,
+    EDITOR_WORLD = 0x1,
+    HAS_PHYSICS = 0x2,
+    HAS_STREAMING = 0x4,
+    HAS_SCENE_STREAMING_LAYER = 0x100,
+    ALL_STREAMING_LAYER_FLAGS = HAS_SCENE_STREAMING_LAYER,
+    DEFAULT = ((HAS_PHYSICS | HAS_STREAMING) | ALL_STREAMING_LAYER_FLAGS)
+end
+extern struct CSMParams
+    NumCascades : uint32
+end
+extern class World : AssetObject
+    GetGame() -> Game
+    GetWorldFlags() -> WorldFlags
+    SetWorldFlags(flags : WorldFlags) -> void
+    GetFogParams() -> FogParams
+    SetFogParams(fogParams : FogParams) -> void
+    GetCSMParams() -> CSMParams
+    SetCSMParams(csmParams : CSMParams) -> void
+    GetCSMState() -> CSMState
+    SetCSMState(csmState : CSMState) -> void
+    GetPhysicsWorld() -> PhysicsWorldBase
+    TryAddSubsystem(subsystem : Subsystem) -> bool
+    GetSubsystemByName(name : any) -> Subsystem
+    RemoveSubsystem(subsystem : Subsystem) -> bool
+    GetWorldGrid() -> WorldGrid
+    GetGameState() -> GameState
+    AddScene(scene : Scene, addToStreamingLayer : bool) -> void
+    RemoveScene(scene : Scene, removeFromStreamingLayer : bool) -> bool
+    HasScene(sceneId : any) -> bool
+    GetSceneByName(nameHash : any) -> Scene
+    GetScenes() -> Array<Scene>
+    AddView(view : View) -> void
+    RemoveView(view : View) -> void
+    AddSystem(system : SystemBase) -> SystemBase
+    RemoveSystem(system : SystemBase) -> bool
+    OnSceneAdded : any
+    OnSceneRemoved : any
+    DeserializeNonStreamingScenes(scenes : Array<Scene>) -> void
+    SerializeNonStreamingScenes() -> Array<Scene>
+    DeserializeStreamingLayers(streamingLayers : Array<WGLayerDesc>) -> void
+    SerializeStreamingLayers() -> Array<WGLayerDesc>
+    DeserializeSystems(systems : Array<SystemBase>) -> void
+    SerializeSystems() -> Array<SystemBase>
+    GameInstance : Game
+    WorldFlags : WorldFlags
+    Scenes : Array<Scene>
+    FogParams : FogParams
+    CsmParams : CSMParams
+    CsmState : CSMState
+    Systems : Array<SystemBase>
+end
+extern class PhysicsShape : AssetObject
+end
+extern class PlanePhysicsShape : PhysicsShape
+    Plane : Vec4f
+end
+extern class BoxPhysicsShape : PhysicsShape
+    Aabb : BoundingBox
+end
+extern class ConvexHullPhysicsShape : PhysicsShape
+end
+extern class SpherePhysicsShape : PhysicsShape
+    Sphere : BoundingSphere
+end
+extern class CapsulePhysicsShape : PhysicsShape
+    Radius : float
+    Height : float
+end
+extern enum PhysicsShapeType : uint8
+    BOX,
+    SPHERE,
+    PLANE,
+    CONVEX_HULL,
+    CAPSULE
 end
 extern struct ShaderInputGroup
     Elements : Array<ShaderInputSet>
@@ -2348,26 +1975,6 @@ extern class ShaderBundle : AssetObject
     CompiledShaders : Array<Shader>
     ErrorMessages : Array<string>
 end
-extern class Texture : AssetObject
-    Rename(name : Name) -> Result
-    TextureDesc : TextureDesc
-    ImageData : BlobDataReference
-    GpuImage : any
-end
-extern class Shader : AssetObject
-    BaseName : Name
-    InputLayout : VertexInputLayoutDesc
-    InputGroup : ShaderInputGroup
-    ModuleTypes : Array<ShaderModuleType>
-    ModuleNames : Array<string>
-    EntryPointNames : Array<string>
-    ShaderBlobs : Array<BlobDataReference>
-    PropertySetHashCode : HashCode
-    LastCompiledTimestamp : Time
-    Properties : ShaderPropertySet
-    SerializeProperties() -> Array<ShaderProperty>
-    DeserializeProperties(properties : Array<ShaderProperty>) -> void
-end
 extern enum MeshFlags : uint32
     None = 0x0,
     ViewIndependent = 0x1
@@ -2392,6 +1999,26 @@ extern class Mesh : AssetObject
     Bvh : BVHNode
     Flags : MeshFlags
 end
+extern class Shader : AssetObject
+    BaseName : Name
+    InputLayout : VertexInputLayoutDesc
+    InputGroup : ShaderInputGroup
+    ModuleTypes : Array<ShaderModuleType>
+    ModuleNames : Array<string>
+    EntryPointNames : Array<string>
+    ShaderBlobs : Array<BlobDataReference>
+    PropertySetHashCode : HashCode
+    LastCompiledTimestamp : Time
+    Properties : ShaderPropertySet
+    SerializeProperties() -> Array<ShaderProperty>
+    DeserializeProperties(properties : Array<ShaderProperty>) -> void
+end
+extern class Texture : AssetObject
+    Rename(name : Name) -> Result
+    TextureDesc : TextureDesc
+    ImageData : BlobDataReference
+    GpuImage : any
+end
 extern class MaterialInstance : AssetObject
     IsStatic() -> bool
     GetIsDynamic() -> bool
@@ -2402,110 +2029,418 @@ extern class MaterialInstance : AssetObject
     Textures : MaterialTextures
     IsDynamic : bool
 end
-extern class MaterialDefinition : AssetObject
-    Attributes : MaterialAttributes
-    DefaultParameters : MaterialParameters
-    DefaultTextures : MaterialTextures
-end
 extern class InstancedMeshData : AssetObject
     Buffers : Array<BlobDataReference>
     BufferStructSizes : Array<uint32>
     BufferStructAlignments : Array<uint32>
 end
-extern class PhysicsShape : AssetObject
+extern class MaterialDefinition : AssetObject
+    Attributes : MaterialAttributes
+    DefaultParameters : MaterialParameters
+    DefaultTextures : MaterialTextures
 end
-extern class PlanePhysicsShape : PhysicsShape
-    Plane : Vec4f
+extern class ScriptAsset : AssetObject
 end
-extern class BoxPhysicsShape : PhysicsShape
-    Aabb : BoundingBox
+extern struct FontAtlasTextureSet
+    MainAtlas : Texture
+    Atlases : Array<any>
 end
-extern class ConvexHullPhysicsShape : PhysicsShape
+extern class FontAtlas : AssetObject
+    AtlasTextures : FontAtlasTextureSet
+    CellDimensions : Vec2i
+    GlyphMetrics : Array<GlyphMetrics>
+    SymbolList : Array<uint32>
 end
-extern class SpherePhysicsShape : PhysicsShape
-    Sphere : BoundingSphere
+extern struct AssetReference
+    GetAssetPath() -> AssetPath
+    SetAssetPath(assetPath : AssetPath) -> void
 end
-extern class CapsulePhysicsShape : PhysicsShape
-    Radius : float
-    Height : float
+extern class AssetRegistry
+    GetRootPath() -> string
+    SetRootPath(rootPath : string) -> void
 end
-extern enum PhysicsShapeType : uint8
-    BOX,
-    SPHERE,
-    PLANE,
-    CONVEX_HULL,
-    CAPSULE
+extern struct BlobDataReference
+    Key : Name
+    Size : uint64
+    Raw : any
+    ReadOnly : bool
+end
+extern class BlobStorage
+    BaseDirectory : string
+    PageSize : uint64
+    FreeRanges : Array<BlobMappingRange>
+    PageData : Array<BlobPageData>
+end
+extern struct BlobPageData
+    Cursor : uint64
+end
+extern struct BlobMappingRange
+    Start : uint32
+    End : uint32
 end
 extern class AssetLoaderBase
 end
-extern struct AssetBucket
+extern struct ScriptDesc
+    Uuid : UUID
+    Language : ScriptLanguage
+    Path : Array<any>
+    AssemblyPath : Array<any>
+    ClassName : Array<any>
+    CompileStatus : uint32
+    HotReloadVersion : int32
+    LastModifiedTimestamp : uint64
 end
-extern struct UUID
-    Data0 : uint64
-    Data1 : uint64
-    ToString() -> string
+extern struct PropertyHandle
 end
-extern struct Time
-    Value : uint64
+extern struct FieldHandle
 end
-extern struct Result
-    HasValue() -> bool
-    HasError() -> bool
-    GetError() -> Error
+extern struct MethodHandle
 end
-extern struct Error
+extern class Reflection
+    static GetClassByName(name : Name) -> Class
+    static GetFields(classRef : Class) -> Array<FieldHandle>
+    static GetFieldHandle(classRef : Class, fieldName : Name) -> FieldHandle
+    static GetFieldValue(field : FieldHandle, target : any) -> any
+    static SetFieldValue(field : FieldHandle, target : any, value : any) -> void
+    static GetFieldName(field : FieldHandle) -> Name
+    static GetMethods(classRef : Class) -> Array<MethodHandle>
+    static GetMethodHandle(classRef : Class, methodName : Name) -> MethodHandle
+    static InvokeMethod(method : MethodHandle, args : Array<any>) -> any
+    static GetMethodName(method : MethodHandle) -> Name
+    static GetProperties(classRef : Class) -> Array<PropertyHandle>
+    static GetPropertyHandle(classRef : Class, propertyName : Name) -> PropertyHandle
+    static GetPropertyValue(property : PropertyHandle, target : any) -> any
+    static SetPropertyValue(property : PropertyHandle, target : any, value : any) -> void
+    static GetPropertyName(property : PropertyHandle) -> Name
 end
-extern struct TypeId
+extern class Debugger
+    static Breakpoint() -> void
+    static AssertTrue(condition : bool) -> void
+    static AssertFalse(condition : bool) -> void
 end
-extern struct Triangle
-    Points : Array<Vec3f>
+extern enum ScriptLanguage : uint32
+    Invalid = ~0u,
+    Native = 0,
+    HypScript = 1,
+    CSharp = 2
 end
-extern struct Transform
-    Translation : Vec3f
-    Scale : Vec3f
-    Rotation : Quat4f
+extern enum ScriptCompileStatus : uint32
+    Uninitialized = 0x0,
+    Compiled = 0x1,
+    Dirty = 0x2,
+    Processing = 0x4,
+    Errored = 0x8
 end
-extern struct Ray
-    Position : Vec3f
-    Direction : Vec3f
+extern struct GlyphMetrics
+    Width : uint16
+    Height : uint16
+    BearingX : int16
+    BearingY : int16
+    Advance : uint32
+    ImagePosition : Vec2i
 end
-extern enum RayTestFlags : uint32
-    None = 0x0,
-    TestBVH = 0x1,
-    EditorPick = 0x2,
-    Max = 0xFFFFFFFF
+extern class OverlayBase
+    GetUIObject() -> UIObject
+    GetPlacement() -> int
+    Update(delta : float) -> void
+    CreateUIObject(spawnParent : UIObject) -> UIObject
+    IsEnabled() -> bool
+    CreateUIObject_Impl(spawnParent : UIObject) -> UIObject
+    GetPlacement_Impl() -> int
+    Update_Impl(delta : float) -> void
+    IsEnabled_Impl() -> bool
 end
-extern struct Quat4f
+extern class NullOverlay : OverlayBase
+end
+extern class TextureOverlay : OverlayBase
+    CreateUIObject_Impl(spawnParent : UIObject) -> UIObject
+    GetPlacement_Impl() -> int
+end
+extern class TextOverlay : OverlayBase
+    CreateUIObject_Impl(spawnParent : UIObject) -> UIObject
+end
+extern class ConsoleOverlay : OverlayBase
+    CreateUIObject_Impl(spawnParent : UIObject) -> UIObject
+    GetPlacement_Impl() -> int
+    Update_Impl(delta : float) -> void
+    IsEnabled_Impl() -> bool
+end
+extern class BaseStatsOverlay : OverlayBase
+    CreateUIObject_Impl(spawnParent : UIObject) -> UIObject
+    GetPlacement_Impl() -> int
+    Update_Impl(delta : float) -> void
+    IsEnabled_Impl() -> bool
+end
+extern class DeviceDetailsOverlay : OverlayBase
+    CreateUIObject_Impl(spawnParent : UIObject) -> UIObject
+    GetPlacement_Impl() -> int
+    Update_Impl(delta : float) -> void
+    IsEnabled_Impl() -> bool
+end
+extern class StatsOverlay : OverlayBase
+    CreateUIObject_Impl(spawnParent : UIObject) -> UIObject
+    GetPlacement_Impl() -> int
+    Update_Impl(delta : float) -> void
+    IsEnabled_Impl() -> bool
+end
+extern enum ScrollAxis : uint8
+    SA_NONE = 0x0,
+    SA_HORIZONTAL = 0x1,
+    SA_VERTICAL = 0x2,
+    SA_ALL = (SA_HORIZONTAL | SA_VERTICAL)
+end
+extern enum UIObjectFocusState : uint32
+    NONE = 0x0,
+    HOVER = 0x1,
+    PRESSED = 0x2,
+    TOGGLED = 0x4,
+    FOCUSED = 0x8
+end
+extern enum UIObjectUpdateType : uint32
+    NONE = 0x0,
+    UPDATE_SIZE = 0x1,
+    UPDATE_POSITION = 0x2,
+    UPDATE_MATERIAL = 0x4,
+    UPDATE_MESH_DATA = 0x8,
+    UPDATE_COMPUTED_VISIBILITY = 0x10,
+    UPDATE_CLAMPED_SIZE = 0x20,
+    UPDATE_CUSTOM = 0x40,
+    UPDATE_ALL = UINT16_MAX,
+    UPDATE_CHILDREN_SIZE = (UPDATE_SIZE << 16),
+    UPDATE_CHILDREN_POSITION = (UPDATE_POSITION << 16),
+    UPDATE_CHILDREN_MATERIAL = (UPDATE_MATERIAL << 16),
+    UPDATE_CHILDREN_MESH_DATA = (UPDATE_MESH_DATA << 16),
+    UPDATE_CHILDREN_COMPUTED_VISIBILITY = (UPDATE_COMPUTED_VISIBILITY << 16),
+    UPDATE_CHILDREN_CLAMPED_SIZE = (UPDATE_CLAMPED_SIZE << 16),
+    UPDATE_CHILDREN_CUSTOM = (UPDATE_CUSTOM << 16),
+    UPDATE_CHILDREN_ALL = (UPDATE_ALL << 16)
+end
+extern enum UIObjectBorderFlags : uint32
+    NONE = 0x0,
+    TOP = 0x1,
+    LEFT = 0x2,
+    BOTTOM = 0x4,
+    RIGHT = 0x8,
+    ALL = (((TOP | LEFT) | BOTTOM) | RIGHT)
+end
+extern struct UIEventHandlerResult
+end
+extern enum UIObjectAlignment : uint32
+    TOP_LEFT = 0,
+    TOP_RIGHT = 1,
+    CENTER = 2,
+    BOTTOM_LEFT = 3,
+    BOTTOM_RIGHT = 4
+end
+extern enum UIObjectUpdateSizeFlags : uint32
+    NONE = 0x0,
+    MAX_SIZE = 0x1,
+    INNER_SIZE = 0x2,
+    OUTER_SIZE = 0x4,
+    DEFAULT = ((MAX_SIZE | INNER_SIZE) | OUTER_SIZE)
+end
+extern struct UIObjectAspectRatio
     X : float
     Y : float
-    Z : float
-    W : float
 end
-extern struct Mat4f
+extern struct UIObjectSize
+    Flags : uint64
+    Value : Vec2i
 end
-extern struct Mat3f
+extern class UIObject
+    GetEntity() -> Entity
+    GetStage() -> UIStage
+    SetStage(stage : UIStage) -> void
+    GetName() -> Name
+    SetName(name : Name) -> void
+    GetPosition() -> Vec2i
+    SetPosition(position : Vec2i) -> void
+    GetOffsetPosition() -> Vec2f
+    GetAbsolutePosition() -> Vec2f
+    IsPositionAbsolute() -> bool
+    SetIsPositionAbsolute(isPositionAbsolute : bool) -> void
+    GetSize() -> UIObjectSize
+    SetSize(size : UIObjectSize) -> void
+    GetInnerSize() -> UIObjectSize
+    SetInnerSize(size : UIObjectSize) -> void
+    GetMaxSize() -> UIObjectSize
+    SetMaxSize(size : UIObjectSize) -> void
+    GetActualSize() -> Vec2i
+    GetActualSizeClamped() -> Vec2i
+    GetActualInnerSize() -> Vec2i
+    GetScrollOffset() -> Vec2f
+    SetScrollOffset(scrollOffset : Vec2f, smooth : bool) -> void
+    ScrollToChild(child : UIObject) -> void
+    GetVerticalScrollbarSize() -> int
+    GetHorizontalScrollbarSize() -> int
+    CanScrollOnAxis(axis : ScrollAxis) -> bool
+    GetComputedDepth() -> int
+    GetDepth() -> int
+    SetDepth(depth : int) -> void
+    AcceptsFocus() -> bool
+    SetAcceptsFocus(acceptsFocus : bool) -> void
+    NeedsUpdate() -> bool
+    Focus() -> void
+    Blur(blurChildren : bool) -> void
+    SetAffectsParentSize(affectsParentSize : bool) -> void
+    AffectsParentSize() -> bool
+    GetBorderRadius() -> uint32
+    SetBorderRadius(borderRadius : uint32) -> void
+    GetBorderFlags() -> UIObjectBorderFlags
+    SetBorderFlags(borderFlags : UIObjectBorderFlags) -> void
+    GetAspectRatio() -> UIObjectAspectRatio
+    SetAspectRatio(aspectRatio : UIObjectAspectRatio) -> void
+    GetPadding() -> Vec2i
+    SetPadding(padding : Vec2i) -> void
+    GetBackgroundColor() -> Color
+    SetBackgroundColor(backgroundColor : Color) -> void
+    GetTextColor() -> Color
+    SetTextColor(textColor : Color) -> void
+    GetText() -> string
+    SetText(text : string) -> void
+    GetTextSize() -> float
+    SetTextSize(textSize : float) -> void
+    IsVisible() -> bool
+    SetIsVisible(isVisible : bool) -> void
+    IsEnabled() -> bool
+    SetIsEnabled(isEnabled : bool) -> void
+    GetParentUIObject() -> UIObject
+    AddChildUIObject(uiObject : UIObject) -> void
+    RemoveChildUIObject(uiObject : UIObject) -> bool
+    ClearDeep() -> void
+    RemoveFromParent() -> bool
+    DetachFromParent() -> UIObject
+    HasChildUIObjects() -> bool
+    GetChildUIObject(index : int) -> UIObject
+    NumChildUIObjects(deep : bool) -> uint32
+    GetNode() -> Node
+    GetWorld() -> World
+    GetAABB() -> BoundingBox
+    GetAABBClamped() -> BoundingBox
+    GetDataSource() -> UIDataSourceBase
+    SetDataSource(dataSource : UIDataSourceBase) -> void
+    OnInit : any
+    OnAttached : any
+    OnRemoved : any
+    OnChildAttached : any
+    OnChildRemoved : any
+    OnMouseDown : any
+    OnMouseUp : any
+    OnMouseDrag : any
+    OnMouseHover : any
+    OnMouseLeave : any
+    OnMouseMove : any
+    OnGainFocus : any
+    OnLoseFocus : any
+    OnScroll : any
+    OnClick : any
+    OnRightClick : any
+    OnKeyDown : any
+    OnKeyUp : any
+    OnTextChange : any
+    OnSizeChange : any
+    OnComputedVisibilityChange : any
+    OnEnabled : any
+    OnDisabled : any
+    OnValueChange : any
+    Init() -> void
 end
-extern struct Frustum
-    Planes : Array<Vec4f>
-    Corners : Array<Vec3f>
+extern class UIConsole : UIObject
 end
-extern struct Color
-    GetRed() -> float
-    SetRed(red : float) -> Color
-    GetGreen() -> float
-    SetGreen(green : float) -> Color
-    GetBlue() -> float
-    SetBlue(blue : float) -> Color
-    GetAlpha() -> float
-    SetAlpha(alpha : float) -> Color
+extern class UIButton : UIObject
 end
-extern struct BoundingSphere
-    Center : Vec3f
-    Radius : float
+extern class UIText : UIObject
+    GetCharacterOffset(characterIndex : int) -> Vec2f
 end
-extern struct BoundingBox
-    Min : Vec3f
-    Max : Vec3f
+extern class UIImage : UIObject
+end
+extern class UIStage : UIObject
+    GetSurfaceSize() -> Vec2i
+    SetSurfaceSize(surfaceSize : Vec2i) -> void
+    GetScene() -> Scene
+    SetScene(scene : Scene) -> void
+    GetCamera() -> Camera
+end
+extern class UIPanel : UIObject
+    IsHorizontalScrollEnabled() -> bool
+    IsVerticalScrollEnabled() -> bool
+    SetIsScrollEnabled(axis : ScrollAxis, isScrollEnabled : bool) -> void
+end
+extern class EditorPropertyPanelBase : UIPanel
+    Build(boxed : any, property : any) -> void
+end
+extern class UITextbox : UIPanel
+    GetPlaceholder() -> string
+    SetPlaceholder(placeholder : string) -> void
+    GetPlaceholderTextColor() -> Color
+    ClearOnSubmit : bool
+end
+extern enum UIListViewOrientation : uint8
+    VERTICAL = 0,
+    HORIZONTAL
+end
+extern class UIListView : UIPanel
+    SetSelectedItem(listViewItem : UIListViewItem) -> void
+    GetSelectedItemIndex() -> int
+    SetSelectedItemIndex(index : int) -> void
+    GetOrientation() -> UIListViewOrientation
+    SetOrientation(orientation : UIListViewOrientation) -> void
+end
+extern class UIListViewItem : UIObject
+end
+extern class UITabView : UIPanel
+end
+extern class UITab : UIObject
+end
+extern class UIWindow : UIPanel
+end
+extern class UIDockableContainer : UIPanel
+end
+extern class UIDockableItem : UIPanel
+end
+extern class UIMenuBar : UIPanel
+    GetDropDirection() -> UIMenuBarDropDirection
+    SetDropDirection(dropDirection : UIMenuBarDropDirection) -> void
+    SetSelectedMenuItemIndex(index : uint32) -> void
+    AddMenuItem(name : Name, text : string) -> UIMenuItem
+    GetMenuItem(name : Name) -> UIMenuItem
+    GetMenuItemIndex(name : Name) -> uint32
+    RemoveMenuItem(name : Name) -> bool
+end
+extern class UIMenuItem : UIObject
+end
+extern enum UIMenuBarDropDirection : uint32
+    DOWN,
+    UP
+end
+extern class UIGrid : UIPanel
+    GetNumColumns() -> int
+    SetNumColumns(numColumns : int) -> void
+    GetNumRows() -> uint32
+    SetNumRows(numRows : uint32) -> void
+end
+extern class UIGridRow : UIPanel
+end
+extern class UIGridColumn : UIPanel
+    GetColumnSize() -> int
+    SetColumnSize(columnSize : int) -> void
+end
+extern class UISpacer : UIObject
+end
+extern class UIDataSourceBase
+    Size() -> int
+    Clear() -> void
+end
+extern class UIDataSource : UIDataSourceBase
+    Size() -> int
+    Clear() -> void
+end
+extern class UIElementFactoryBase
+    GetElementTypeId() -> TypeId
+    CreateUIObject(parent : UIObject, value : any, context : any) -> UIObject
+    UpdateUIObject(uiObject : UIObject, value : any, context : any) -> void
+end
+extern struct TypeId
 end
 extern enum LogLevel : uint8
     Fatal,
@@ -2523,6 +2458,71 @@ end
 extern class Logger
     static MakeScriptLogger() -> Logger
     LogScript(channel : LogChannel, level : LogLevel, message : string) -> void
+end
+extern struct Result
+    HasValue() -> bool
+    HasError() -> bool
+    GetError() -> Error
+end
+extern struct Error
+end
+extern struct UUID
+    Data0 : uint64
+    Data1 : uint64
+    ToString() -> string
+end
+extern struct Time
+    Value : uint64
+end
+extern struct Quat4f
+    X : float
+    Y : float
+    Z : float
+    W : float
+end
+extern struct BoundingBox
+    Min : Vec3f
+    Max : Vec3f
+end
+extern struct Color
+    GetRed() -> float
+    SetRed(red : float) -> Color
+    GetGreen() -> float
+    SetGreen(green : float) -> Color
+    GetBlue() -> float
+    SetBlue(blue : float) -> Color
+    GetAlpha() -> float
+    SetAlpha(alpha : float) -> Color
+end
+extern struct Frustum
+    Planes : Array<Vec4f>
+    Corners : Array<Vec3f>
+end
+extern struct Ray
+    Position : Vec3f
+    Direction : Vec3f
+end
+extern enum RayTestFlags : uint32
+    None = 0x0,
+    TestBVH = 0x1,
+    EditorPick = 0x2,
+    Max = 0xFFFFFFFF
+end
+extern struct BoundingSphere
+    Center : Vec3f
+    Radius : float
+end
+extern struct Triangle
+    Points : Array<Vec3f>
+end
+extern struct Mat4f
+end
+extern struct Transform
+    Translation : Vec3f
+    Scale : Vec3f
+    Rotation : Quat4f
+end
+extern struct Mat3f
 end
 extern enum CommandLineArgumentType : uint8
     STRING,

--- a/Data/Scripts/Lib.hyp
+++ b/Data/Scripts/Lib.hyp
@@ -2218,6 +2218,18 @@ extern enum EnvProbeFlags : uint32
     EPF_PARALLAX_CORRECTED = 0x1,
     EPF_BAKED = 0x2
 end
+extern class Sprite : Entity
+end
+extern enum SpriteType : uint32
+    None = 0,
+    Point2D,
+    Spot3D,
+    Crosshair,
+    EnvProbe,
+    LightmapVolume,
+    Camera,
+    Max
+end
 extern class Light : Entity
     GetLightType() -> LightType
     GetLightFlags() -> LightFlags

--- a/Source/Core/Constants.hpp
+++ b/Source/Core/Constants.hpp
@@ -50,6 +50,7 @@ constexpr uint32 MaxBoundCameras = 1024;
 constexpr uint32 MaxBoundLights = 1024;
 constexpr uint32 MaxBoundEntities = 1u << 15; // 32768
 constexpr uint32 MaxBoundMaterials = 1u << 10; // 1024
+constexpr uint32 MaxBoundSprites = 1u << 14; // 16384
 constexpr uint32 MaxBoundSkeletons = 64;
 constexpr uint32 MaxBoundEnvProbes = 256;
 constexpr uint32 MaxBoundReflectionProbes = 16;

--- a/Source/Core/functional/Delegate.hpp
+++ b/Source/Core/functional/Delegate.hpp
@@ -45,8 +45,6 @@ using threading::ThreadSleep;
 
 namespace functional {
 
-class IDelegate;
-
 template <class ReturnType, class... Args>
 class Delegate;
 
@@ -235,17 +233,6 @@ struct DelegateHandler
 
         return false;
     }
-};
-
-class IDelegate
-{
-public:
-    virtual ~IDelegate() = default;
-
-    virtual bool AnyBound() const = 0;
-
-    virtual bool Remove(DelegateHandler&& handler) = 0;
-    virtual int RemoveAllDetached() = 0;
 };
 
 /*! \brief A Delegate object that can be used to bind handler functions to be called when a broadcast is sent.
@@ -767,7 +754,7 @@ protected:
 };
 
 template <class ReturnType, class... Args>
-class Delegate : public virtual IDelegate
+class Delegate
 {
 public:
     friend class DelegateHandlerSet;
@@ -788,7 +775,7 @@ public:
 
     Delegate& operator=(Delegate&& other) noexcept = delete;
 
-    virtual ~Delegate() override
+    ~Delegate()
     {
         // Ensure that the delegate is not being used by any threads before deleting it
         TUniqueLock guard(m_mtx);
@@ -811,7 +798,7 @@ public:
         return Delegate::AnyBound();
     }
 
-    virtual bool AnyBound() const override final
+    bool AnyBound() const
     {
         TSharedLock guard(m_mtx);
 
@@ -883,7 +870,7 @@ public:
     /*! \brief Remove all detached handlers from the Delegate.
      *  \note Only detached handlers are removed, as removing bound handlers would cause them to hold dangling pointers.
      *  \return The number of handlers removed. */
-    int RemoveAllDetached() override
+    int RemoveAllDetached()
     {
         TSharedLock guard(m_mtx);
 
@@ -895,7 +882,7 @@ public:
         return m_impl->RemoveAllDetached();
     }
 
-    bool Remove(DelegateHandler&& handle) override
+    bool Remove(DelegateHandler&& handle)
     {
         TSharedLock guard(m_mtx);
 
@@ -1064,7 +1051,6 @@ inline constexpr bool IsDelegateV = IsDelegate<T>::value;
 using functional::Delegate;
 using functional::DelegateHandler;
 using functional::DelegateHandlerSet;
-using functional::IDelegate;
 using functional::IsDelegate;
 using functional::IsDelegateV;
 

--- a/Source/Core/reflection/ObjectFwd.hpp
+++ b/Source/Core/reflection/ObjectFwd.hpp
@@ -286,9 +286,99 @@ const Class* GetClass()
 /// Casts ///
 
 template <class Other, class T>
-static inline Other* ObjCast(T* objectPtr)
+static inline Other* StaticCast(T* objectPtr)
 {
-    static_assert(std::is_class_v<Other>, "Other must be a class type to use with ObjCast");
+    static_assert(std::is_class_v<Other>, "Other must be a class type to use with StaticCast");
+
+    if constexpr (std::is_same_v<T, Other> || std::is_base_of_v<Other, T> || std::is_base_of_v<T, Other>)
+    {
+        return static_cast<Other*>(objectPtr);
+    }
+    else
+    {
+        static_assert(always_fail_v<T>, "Invalid StaticCast");
+    }
+}
+
+template <class Other, class T>
+static inline const Other* StaticCast(const T* objectPtr)
+{
+    static_assert(std::is_class_v<Other>, "Other must be a class type to use with StaticCast");
+
+    if constexpr (std::is_same_v<T, Other> || std::is_base_of_v<Other, T> || std::is_base_of_v<T, Other>)
+    {
+        return static_cast<const Other*>(objectPtr);
+    }
+    else
+    {
+        static_assert(always_fail_v<T>, "Invalid StaticCast");
+    }
+}
+
+template <class Other, class T>
+static inline const Handle<Other>& StaticCast(const Handle<T>& handle)
+{
+    static_assert(std::is_class_v<Other>, "Other must be a class type to use with StaticCast");
+
+    if constexpr (std::is_same_v<T, Other> || std::is_base_of_v<Other, T> || std::is_base_of_v<T, Other>)
+    {
+        return reinterpret_cast<const Handle<Other>&>(handle);
+    }
+    else
+    {
+        static_assert(always_fail_v<T>, "Invalid StaticCast");
+    }
+}
+
+template <class Other, class T>
+static inline Handle<Other> StaticCast(Handle<T>&& handle)
+{
+    static_assert(std::is_class_v<Other>, "Other must be a class type to use with StaticCast");
+
+    if constexpr (std::is_same_v<T, Other> || std::is_base_of_v<Other, T> || std::is_base_of_v<T, Other>)
+    {
+        return reinterpret_cast<Handle<Other>&&>(handle);
+    }
+    else
+    {
+        static_assert(always_fail_v<T>, "Invalid StaticCast");
+    }
+}
+
+template <class Other, class T>
+static inline const WeakHandle<Other>& StaticCast(const WeakHandle<T>& handle)
+{
+    static_assert(std::is_class_v<Other>, "Other must be a class type to use with StaticCast");
+
+    if constexpr (std::is_same_v<T, Other> || std::is_base_of_v<Other, T> || std::is_base_of_v<T, Other>)
+    {
+        return reinterpret_cast<const WeakHandle<Other>&>(handle);
+    }
+    else
+    {
+        static_assert(always_fail_v<T>, "Invalid StaticCast");
+    }
+}
+
+template <class Other, class T>
+static inline WeakHandle<Other> StaticCast(WeakHandle<T>&& handle)
+{
+    static_assert(std::is_class_v<Other>, "Other must be a class type to use with StaticCast");
+
+    if constexpr (std::is_same_v<T, Other> || std::is_base_of_v<Other, T> || std::is_base_of_v<T, Other>)
+    {
+        return reinterpret_cast<WeakHandle<Other>&&>(handle);
+    }
+    else
+    {
+        static_assert(always_fail_v<T>, "Invalid StaticCast");
+    }
+}
+
+template <class Other, class T>
+static inline Other* DynamicCast(T* objectPtr)
+{
+    static_assert(std::is_class_v<Other>, "Other must be a class type to use with DynamicCast");
 
     if constexpr (std::is_same_v<T, Other> || std::is_base_of_v<Other, T>)
     {
@@ -304,9 +394,9 @@ static inline Other* ObjCast(T* objectPtr)
 }
 
 template <class Other, class T>
-static inline const Other* ObjCast(const T* objectPtr)
+static inline const Other* DynamicCast(const T* objectPtr)
 {
-    static_assert(std::is_class_v<Other>, "Other must be a class type to use with ObjCast");
+    static_assert(std::is_class_v<Other>, "Other must be a class type to use with DynamicCast");
 
     if constexpr (std::is_same_v<T, Other> || std::is_base_of_v<Other, T>)
     {
@@ -322,9 +412,9 @@ static inline const Other* ObjCast(const T* objectPtr)
 }
 
 template <class Other, class T>
-static inline const Handle<Other>& ObjCast(const Handle<T>& handle)
+static inline const Handle<Other>& DynamicCast(const Handle<T>& handle)
 {
-    static_assert(std::is_class_v<Other>, "Other must be a class type to use with ObjCast");
+    static_assert(std::is_class_v<Other>, "Other must be a class type to use with DynamicCast");
 
     if (!handle.IsValid())
     {
@@ -340,9 +430,9 @@ static inline const Handle<Other>& ObjCast(const Handle<T>& handle)
 }
 
 template <class Other, class T>
-static inline Handle<Other> ObjCast(Handle<T>&& handle)
+static inline Handle<Other> DynamicCast(Handle<T>&& handle)
 {
-    static_assert(std::is_class_v<Other>, "Other must be a class type to use with ObjCast");
+    static_assert(std::is_class_v<Other>, "Other must be a class type to use with DynamicCast");
 
     if (!handle.IsValid())
     {
@@ -358,9 +448,9 @@ static inline Handle<Other> ObjCast(Handle<T>&& handle)
 }
 
 template <class Other, class T>
-static inline const WeakHandle<Other>& ObjCast(const WeakHandle<T>& handle)
+static inline const WeakHandle<Other>& DynamicCast(const WeakHandle<T>& handle)
 {
-    static_assert(std::is_class_v<Other>, "Other must be a class type to use with ObjCast");
+    static_assert(std::is_class_v<Other>, "Other must be a class type to use with DynamicCast");
 
     if (!handle.IsValid())
     {
@@ -376,9 +466,9 @@ static inline const WeakHandle<Other>& ObjCast(const WeakHandle<T>& handle)
 }
 
 template <class Other, class T>
-static inline WeakHandle<Other> ObjCast(WeakHandle<T>&& handle)
+static inline WeakHandle<Other> DynamicCast(WeakHandle<T>&& handle)
 {
-    static_assert(std::is_class_v<Other>, "Other must be a class type to use with ObjCast");
+    static_assert(std::is_class_v<Other>, "Other must be a class type to use with DynamicCast");
 
     if (!handle.IsValid())
     {

--- a/Source/Core/serialization/SerializationUtils.cpp
+++ b/Source/Core/serialization/SerializationUtils.cpp
@@ -1911,7 +1911,7 @@ Result BoxedFromJSON(const JSON::Value& jsonValue, const TypeInfo& typeInfo, Box
                         return HYP_MAKE_ERROR(Error, "Failed to create instance of variant type {}", typeInfo.name);
                     }
 
-                    if (variantHandler->SetValue(variantInstance, BoxedValue(num)))
+                    if (variantHandler->SetValue(variantInstance, BoxedValue(static_cast<int64>(num))))
                     {
                         outBoxed = std::move(variantInstance);
                         return {};

--- a/Source/Core/threading/ThreadPool.cpp
+++ b/Source/Core/threading/ThreadPool.cpp
@@ -113,7 +113,7 @@ ThreadBase* ThreadPoolBase::GetNextThread()
 
 ThreadId ThreadPoolBase::CreateTaskThreadId(ANSIStringView baseName, uint32 threadIndex)
 {
-    return ThreadId(Name::Unique(HYP_FORMAT("{}{}", baseName, threadIndex).Data()), THREAD_CATEGORY_TASK);
+    return ThreadId(NAME_FMT("{}{}", baseName, threadIndex), THREAD_CATEGORY_TASK);
 }
 
 #pragma endregion ThreadPoolBase

--- a/Source/Engine/HyperionEngine.cpp
+++ b/Source/Engine/HyperionEngine.cpp
@@ -663,7 +663,7 @@ extern "C"
             return nullptr;
         }
 
-        CocoaApplicationWindow* cocoaWindow = ObjCast<CocoaApplicationWindow>(pWindow);
+        CocoaApplicationWindow* cocoaWindow = DynamicCast<CocoaApplicationWindow>(pWindow);
 
         if (!cocoaWindow)
         {
@@ -931,7 +931,7 @@ extern "C"
     {
         Assert(g_appContext.IsValid());
 
-        if (AndroidAppContext* androidAppContext = ObjCast<AndroidAppContext>(g_appContext))
+        if (AndroidAppContext* androidAppContext = DynamicCast<AndroidAppContext>(g_appContext))
         {
             androidAppContext->SetNativeWindow(nativeWindow);
         }
@@ -942,12 +942,12 @@ extern "C"
         if (!g_appContext.IsValid())
             return;
 
-        AndroidAppContext* ctx = ObjCast<AndroidAppContext>(g_appContext);
+        AndroidAppContext* ctx = DynamicCast<AndroidAppContext>(g_appContext);
 
         if (ctx == nullptr || ctx->GetMainWindow() == nullptr)
             return;
 
-        AndroidApplicationWindow* window = ObjCast<AndroidApplicationWindow>(ctx->GetMainWindow());
+        AndroidApplicationWindow* window = DynamicCast<AndroidApplicationWindow>(ctx->GetMainWindow());
         if (window == nullptr)
             return;
 

--- a/Source/Engine/asset/AssetBucket.hpp
+++ b/Source/Engine/asset/AssetBucket.hpp
@@ -137,7 +137,7 @@ inline constexpr const AssetBucket& GetAssetBucketByName(StringHash nameHash)
     return AssetBuckets::None;
 }
 
-inline static const char* GetAssetBucketName(const uint32 bucketIndex)
+inline const char* GetAssetBucketName(const uint32 bucketIndex)
 {
     static constexpr const char* s_names[MaxAssetBuckets] = {
         nullptr, // 0 = None

--- a/Source/Engine/asset/AssetBucket.hpp
+++ b/Source/Engine/asset/AssetBucket.hpp
@@ -28,15 +28,16 @@ class Class;
     X(Worlds,               10)      \
     X(Scenes,               11)      \
     X(Nodes,                12)      \
-    X(Entities,             13)      \
+    X(Entities,             13)     \
     X(Bones,                14)      \
     X(EnvProbes,            15)      \
     X(LightmapVolumes,      16)      \
-    X(Shaders,              17)      \
-    X(ShaderBundles,        18)      \
+    X(Shaders,              17)     \
+    X(ShaderBundles,        18)     \
     X(FontAtlases,          19)      \
     X(PhysicsShapes,        20)      \
-    X(Scripts,              21)
+    X(Scripts,              21)      \
+    X(Sprites,              22)
 
 const char* GetAssetBucketName(const uint32 bucketIndex);
 

--- a/Source/Engine/asset/AssetObject.cpp
+++ b/Source/Engine/asset/AssetObject.cpp
@@ -110,24 +110,26 @@ void AssetObject::SetAssetFlags(EnumFlags<AssetObjectFlags> flags)
 
 void AssetObject::MarkDirty()
 {
+    if (IsTransient() || !IsRegistered())
+    {
+        return;
+    }
+
     if (IsGlobalContextActive<AssetLoadingContext>())
     {
         return;
     }
 
-    if (IsRegistered() && !IsTransient())
+    Handle<AssetRegistry> registry = GetAssetRegistry();
+    AssertDebug(registry.IsValid());
+
+    if (!registry.IsValid())
     {
-        Handle<AssetRegistry> registry = GetAssetRegistry();
-        AssertDebug(registry.IsValid());
-
-        if (!registry.IsValid())
-        {
-            HYP_LOG(Assets, Warning, "Cannot mark asset '{}' dirty: no active asset registry for path '{}'", m_name, m_assetPath.ToString());
-            return;
-        }
-
-        registry->MarkAssetDirty(*this);
+        HYP_LOG(Assets, Warning, "Cannot mark asset '{}' dirty: no active asset registry for path '{}'", m_name, m_assetPath.ToString());
+        return;
     }
+
+    registry->MarkAssetDirty(*this);
 }
 
 void AssetObject::SetPersistentRequested(
@@ -429,7 +431,7 @@ void AssetObject::AllocateBlobData(BlobDataReference& reference, const void* inD
 
         const size_t countAligned = ByteUtil::AlignAs(count, alignment);
 
-        reference.raw = HYP_ALLOC_ALIGNED(countAligned, alignment);
+        reference.raw = g_assetPool->Allocate(countAligned, alignment);
         Assert(reference.raw != nullptr);
 
         if (inData != nullptr)
@@ -449,7 +451,7 @@ void AssetObject::FreeBlobData(BlobDataReference& reference)
         return;
     }
 
-    HYP_FREE_ALIGNED(reference.raw);
+    g_assetPool->Free(reference.raw);
     reference.raw = nullptr;
 }
 

--- a/Source/Engine/asset/AssetObject.cpp
+++ b/Source/Engine/asset/AssetObject.cpp
@@ -463,7 +463,7 @@ void AssetObject::SetBlobDataResident(bool resident)
     for (auto& tup : tuples)
     {
         const char* magic = tup.GetElement<0>();
-        uint16 version = tup.GetElement<1>();
+        [[maybe_unused]] uint16 version = tup.GetElement<1>();
         BlobDataReference* reference = tup.GetElement<2>();
 
         Assert(reference != nullptr);

--- a/Source/Engine/asset/AssetObject.hpp
+++ b/Source/Engine/asset/AssetObject.hpp
@@ -33,6 +33,7 @@ HYP_DECLARE_LOG_CHANNEL(Assets);
 enum class ChunkId : uint32;
 
 class AssetObject;
+class AssetRegistry;
 class ByteWriter;
 class BlobStorage;
 

--- a/Source/Engine/asset/AssetObject.hpp
+++ b/Source/Engine/asset/AssetObject.hpp
@@ -119,18 +119,6 @@ public:
     }
 
     HYP_METHOD()
-    const FilePath& GetOriginalFilepath() const
-    {
-        return m_originalFilepath;
-    }
-
-    HYP_METHOD()
-    void SetOriginalFilepath(const FilePath& originalFilepath)
-    {
-        m_originalFilepath = originalFilepath;
-    }
-
-    HYP_METHOD()
     const AssetPath& GetPath() const
     {
         return m_assetPath;
@@ -235,9 +223,6 @@ protected:
 
     HYP_FIELD(Property = "AssetFlags", Transient, EditHide)
     EnumFlags<AssetObjectFlags> m_flags;
-
-    HYP_FIELD(EditEnabled = false)
-    FilePath m_originalFilepath; // used to determine if we should skip importing an asset
 
     HYP_FIELD(Property = "AssetIndex", Transient, EditHide)
     uint32 m_assetIndex;

--- a/Source/Engine/asset/AssetReference.hpp
+++ b/Source/Engine/asset/AssetReference.hpp
@@ -187,7 +187,7 @@ public:
     {
         const Handle<AssetObject>& assetObject = AssetReference::Resolve();
 
-        return ObjCast<T>(assetObject);
+        return DynamicCast<T>(assetObject);
     }
 };
 

--- a/Source/Engine/asset/AssetRegistry.hpp
+++ b/Source/Engine/asset/AssetRegistry.hpp
@@ -100,7 +100,7 @@ public:
     {
         if (Handle<AssetObject> asset = GetAsset(bucket, name); asset.IsValid())
         {
-            if (Handle<T> assetCasted = ObjCast<T>(asset); assetCasted.IsValid())
+            if (Handle<T> assetCasted = DynamicCast<T>(asset); assetCasted.IsValid())
             {
                 return assetCasted;
             }

--- a/Source/Engine/asset/model_loaders/GLTFModelLoader.cpp
+++ b/Source/Engine/asset/model_loaders/GLTFModelLoader.cpp
@@ -971,7 +971,7 @@ bool BuildPrimitive(GltfLoadContext& ctx,
         mesh->CalculateNormals();
     }
 
-    mesh->SetOriginalFilepath(FilePath::Relative(ctx.state.filepath, ctx.state.assetManager->GetBasePath()));
+   // mesh->SetOriginalFilepath(FilePath::Relative(ctx.state.filepath, ctx.state.assetManager->GetBasePath()));
     InitObject(mesh);
 
     GetCurrentAssetRegistry()->PutAssetUnique(mesh);

--- a/Source/Engine/asset/model_loaders/OBJModelLoader.cpp
+++ b/Source/Engine/asset/model_loaders/OBJModelLoader.cpp
@@ -437,7 +437,7 @@ LoadedAsset OBJModelLoader::BuildModel(LoaderState& state, OBJModel& model)
 
         //mesh->CalculateNormals();
 
-        mesh->SetOriginalFilepath(FilePath::Relative(state.filepath, state.assetManager->GetBasePath()));
+        //mesh->SetOriginalFilepath(FilePath::Relative(state.filepath, state.assetManager->GetBasePath()));
 
         GetCurrentAssetRegistry()->PutAssetUnique(mesh);
 

--- a/Source/Engine/asset/model_loaders/OgreXMLModelLoader.cpp
+++ b/Source/Engine/asset/model_loaders/OgreXMLModelLoader.cpp
@@ -333,7 +333,7 @@ AssetLoadResult OgreXMLModelLoader::LoadAsset(LoaderState& state) const
 
         mesh->SetMeshData(meshDesc, vertexArrayView, subMesh.indices.ToByteView());
         mesh->CalculateNormals();
-        mesh->SetOriginalFilepath(FilePath::Relative(state.filepath, state.assetManager->GetBasePath()));
+        //mesh->SetOriginalFilepath(FilePath::Relative(state.filepath, state.assetManager->GetBasePath()));
 
         GetCurrentAssetRegistry()->PutAsset(mesh);
 

--- a/Source/Engine/asset/texture_loaders/TextureLoader.cpp
+++ b/Source/Engine/asset/texture_loaders/TextureLoader.cpp
@@ -149,7 +149,7 @@ AssetLoadResult TextureLoader::LoadAsset(LoaderState& state) const
     stbi_image_free(imageBytes);
 
     texture->SetName(assetName);
-    texture->SetOriginalFilepath(FilePath::Relative(state.filepath, state.assetManager->GetBasePath()));
+    //texture->SetOriginalFilepath(FilePath::Relative(state.filepath, state.assetManager->GetBasePath()));
     
     GetCurrentAssetRegistry()->PutAssetUnique(texture);
     

--- a/Source/Engine/baking/lightmap_volume/LightmapVolumeBaker.cpp
+++ b/Source/Engine/baking/lightmap_volume/LightmapVolumeBaker.cpp
@@ -372,9 +372,6 @@ void Baker<LightmapVolume>::OnCompleted_Internal()
             vertexArrayView.layoutDesc = newMeshDesc.meshAttributes.inputLayout;
             vertexArrayView.vertexCount = bakeMesh.vertices.Size();
 
-            // Currently seeing issue with `raw` ptr null on bvh - this assertion can be removed when that is fixed.
-            AssertDebug(mesh->GetBVHDataReference().raw != nullptr);
-
             mesh->SetMeshData(newMeshDesc, vertexArrayView, bakeMesh.indices.ToByteView());
         };
 

--- a/Source/Engine/dotnet/runtime/scene/Sprite.cs
+++ b/Source/Engine/dotnet/runtime/scene/Sprite.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Hyperion
+{
+    [ClassBinding(Name = "Sprite")]
+    public class Sprite : Entity
+    {
+        public Sprite()
+        {
+        }
+    }
+}

--- a/Source/Engine/dotnet/runtime/scene/TextSprite.cs
+++ b/Source/Engine/dotnet/runtime/scene/TextSprite.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Hyperion
+{
+    [ClassBinding(Name = "TextSprite")]
+    public class TextSprite : Sprite
+    {
+        public TextSprite()
+        {
+        }
+    }
+}

--- a/Source/Engine/editor/EditorDelegates.cpp
+++ b/Source/Engine/editor/EditorDelegates.cpp
@@ -151,7 +151,7 @@ void EditorDelegates::Update()
 
     Queue<Scheduler::ScheduledTask> tasks;
 
-    if (uint32 numEnqueued = m_scheduler.NumEnqueued())
+    if (m_scheduler.NumEnqueued() != 0)
     {
         m_scheduler.AcceptAll(tasks);
 

--- a/Source/Engine/editor/EditorSubsystem.cpp
+++ b/Source/Engine/editor/EditorSubsystem.cpp
@@ -365,7 +365,14 @@ void TranslateEditorGizmo::OnDragStart(const Handle<Camera>& camera, const Mouse
         return;
     }
 
-    int axis = axisTag.data.TryGet<int>(-1);
+    int axis = -1;
+    axisTag.data.Visit([&axis](auto&& value)
+        {
+            if constexpr (std::is_integral_v<NormalizedType<decltype(value)>>)
+            {
+                axis = static_cast<int>(value);
+            }
+        });
 
     Handle<Node> focusedNode = m_focusedNode.Lock();
 
@@ -940,10 +947,17 @@ void RotateEditorGizmo::OnDragStart(const Handle<Camera>& camera, const MouseEve
     {
         return;
     }
+    
+    int axis = -1;
+    axisTag.data.Visit([&axis](auto&& value)
+        {
+            if constexpr (std::is_integral_v<NormalizedType<decltype(value)>>)
+            {
+                axis = static_cast<int>(value);
+            }
+        });
 
-    const int axisIndex = axisTag.data.TryGet<int>(-1);
-
-    if (axisIndex < 0)
+    if (axis < 0)
     {
         return;
     }
@@ -958,7 +972,7 @@ void RotateEditorGizmo::OnDragStart(const Handle<Camera>& camera, const MouseEve
     DragData dragData {};
 
     dragData.axis = Vec3f::Zero();
-    dragData.axis[axisIndex] = 1.0f;
+    dragData.axis[axis] = 1.0f;
     dragData.axis = (focusedNode->GetWorldRotation() * dragData.axis).Normalize();
 
     dragData.planePoint = m_node->GetWorldTranslation();

--- a/Source/Engine/editor/EditorSubsystem.cpp
+++ b/Source/Engine/editor/EditorSubsystem.cpp
@@ -27,12 +27,19 @@
 #include <scene/FogVolume.hpp>
 #include <scene/EntityManager.hpp>
 
+#include <scene/System.hpp>
+#include <scene/systems/ScriptSystem.hpp>
+#include <scene/systems/MeshSystem.hpp>
+#include <scene/systems/editor/EditorSpriteSystem.hpp>
+
+#include <scene/sky/DynamicSkySystem.hpp>
+
+#include <scene/camera/Camera.hpp>
+
 #include <scene/components/MeshComponent.hpp>
 #include <scene/components/VisibilityStateComponent.hpp>
 #include <scene/components/BoundingBoxComponent.hpp>
 #include <scene/components/TransformComponent.hpp>
-
-#include <scene/sky/DynamicSkySystem.hpp>
 
 #include <scene/LightmapVolume.hpp>
 #include <scene/Volume.hpp>
@@ -1935,6 +1942,11 @@ void EditorSubsystem::OnAddedToWorld()
     if (!GetWorld()->GetSubsystem<UISubsystem>())
     {
         HYP_FAIL("EditorSubsystem requires UISubsystem to be initialized");
+    }
+
+    if (!GetWorld()->HasSystem<EditorSpriteSystem>())
+    {
+        GetWorld()->AddSystem(MakeHandle<EditorSpriteSystem>());
     }
 
     m_editorScene = MakeHandle<Scene>(NAME("EditorScene"), SceneFlags::FOREGROUND | SceneFlags::EDITOR);

--- a/Source/Engine/editor/EditorSubsystem.cpp
+++ b/Source/Engine/editor/EditorSubsystem.cpp
@@ -36,6 +36,7 @@
 
 #include <scene/LightmapVolume.hpp>
 #include <scene/Volume.hpp>
+#include <scene/Sprite.hpp>
 
 #include <asset/Assets.hpp>
 #include <asset/AssetRegistry.hpp>

--- a/Source/Engine/editor/EditorSubsystem.cpp
+++ b/Source/Engine/editor/EditorSubsystem.cpp
@@ -115,12 +115,12 @@ static ShaderPropertyId s_propUniformScaling = InternShaderProperty(ShaderProper
 #pragma region GenerateLightmapsEditorTask
 
 GenerateLightmapsEditorTask::GenerateLightmapsEditorTask(const Handle<LightmapVolume>& volume)
-    : GenerateLightmapsEditorTask(Array<Handle<ObjectBase>> { { ObjCast<ObjectBase>(volume) } })
+    : GenerateLightmapsEditorTask(Array<Handle<ObjectBase>> { { StaticCast<ObjectBase>(volume) } })
 {
 }
 
 GenerateLightmapsEditorTask::GenerateLightmapsEditorTask(const Handle<ReflectionProbe>& probe)
-    : GenerateLightmapsEditorTask(Array<Handle<ObjectBase>> { { ObjCast<ObjectBase>(probe) } })
+    : GenerateLightmapsEditorTask(Array<Handle<ObjectBase>> { { StaticCast<ObjectBase>(probe) } })
 {
 }
 
@@ -177,17 +177,17 @@ void GenerateLightmapsEditorTask::Start()
     {
         Task<void> task;
 
-        if (source->IsA(LightmapVolume::StaticClass()))
+        if (source->IsA<LightmapVolume>())
         {
-            task = lightmapperSubsystem->EnqueueBake(ObjCast<LightmapVolume>(source));
+            task = lightmapperSubsystem->EnqueueBake(StaticCast<LightmapVolume>(source));
         }
-        else if (source->IsA(ReflectionProbe::StaticClass()))
+        else if (source->IsA<ReflectionProbe>())
         {
-            task = lightmapperSubsystem->EnqueueBake(ObjCast<ReflectionProbe>(source));
+            task = lightmapperSubsystem->EnqueueBake(StaticCast<ReflectionProbe>(source));
         }
-        else if (source->IsA(FogVolume::StaticClass()))
+        else if (source->IsA<FogVolume>())
         {
-            task = lightmapperSubsystem->EnqueueBake(ObjCast<FogVolume>(source));
+            task = lightmapperSubsystem->EnqueueBake(StaticCast<FogVolume>(source));
         }
 
         if (task.IsValid())
@@ -345,7 +345,7 @@ void TranslateEditorGizmo::OnDragStart(const Handle<Camera>& camera, const Mouse
 
     m_dragData.Unset();
 
-    Entity* entity = ObjCast<Entity>(node);
+    Entity* entity = DynamicCast<Entity>(node);
     if (!entity)
     {
         return;
@@ -475,7 +475,7 @@ void TranslateEditorGizmo::OnDragEnd(const Handle<Camera>& camera, const MouseEv
 
 bool TranslateEditorGizmo::OnMouseHover(const Handle<Camera>& camera, const MouseEvent& mouseEvent, const Handle<Node>& node)
 {
-    Entity* entity = ObjCast<Entity>(node);
+    Entity* entity = DynamicCast<Entity>(node);
     if (!entity)
     {
         return false;
@@ -498,7 +498,7 @@ bool TranslateEditorGizmo::OnMouseHover(const Handle<Camera>& camera, const Mous
 
 bool TranslateEditorGizmo::OnMouseLeave(const Handle<Camera>& camera, const MouseEvent& mouseEvent, const Handle<Node>& node)
 {
-    Entity* entity = ObjCast<Entity>(node);
+    Entity* entity = DynamicCast<Entity>(node);
     if (!entity)
     {
         return false;
@@ -534,7 +534,7 @@ bool TranslateEditorGizmo::OnMouseMove(const Handle<Camera>& camera, const Mouse
         return false;
     }
 
-    Entity* entity = ObjCast<Entity>(node);
+    Entity* entity = DynamicCast<Entity>(node);
     if (!entity)
     {
         return false;
@@ -928,7 +928,7 @@ void RotateEditorGizmo::OnDragStart(const Handle<Camera>& camera, const MouseEve
 
     m_dragData.Unset();
 
-    Entity* entity = ObjCast<Entity>(node);
+    Entity* entity = DynamicCast<Entity>(node);
     if (!entity)
     {
         return;
@@ -1040,7 +1040,7 @@ void RotateEditorGizmo::OnDragEnd(const Handle<Camera>& camera, const MouseEvent
 
 bool RotateEditorGizmo::OnMouseHover(const Handle<Camera>& camera, const MouseEvent& mouseEvent, const Handle<Node>& node)
 {
-    Entity* entity = ObjCast<Entity>(node);
+    Entity* entity = DynamicCast<Entity>(node);
     if (!entity)
     {
         return false;
@@ -1063,7 +1063,7 @@ bool RotateEditorGizmo::OnMouseHover(const Handle<Camera>& camera, const MouseEv
 
 bool RotateEditorGizmo::OnMouseLeave(const Handle<Camera>& camera, const MouseEvent& mouseEvent, const Handle<Node>& node)
 {
-    Entity* entity = ObjCast<Entity>(node);
+    Entity* entity = DynamicCast<Entity>(node);
     if (!entity)
     {
         return false;
@@ -1099,7 +1099,7 @@ bool RotateEditorGizmo::OnMouseMove(const Handle<Camera>& camera, const MouseEve
         return false;
     }
 
-    Entity* entity = ObjCast<Entity>(node);
+    Entity* entity = DynamicCast<Entity>(node);
     if (!entity)
     {
         return false;
@@ -1367,7 +1367,7 @@ void VolumeEditorGizmo::OnDragStart(const Handle<Camera>& camera, const MouseEve
 
     m_dragData.Unset();
 
-    Entity* entity = ObjCast<Entity>(node);
+    Entity* entity = DynamicCast<Entity>(node);
     if (!entity)
     {
         return;
@@ -1474,7 +1474,7 @@ void VolumeEditorGizmo::OnDragEnd(const Handle<Camera>& camera, const MouseEvent
 
 bool VolumeEditorGizmo::OnMouseHover(const Handle<Camera>& camera, const MouseEvent& mouseEvent, const Handle<Node>& node)
 {
-    Entity* entity = ObjCast<Entity>(node);
+    Entity* entity = DynamicCast<Entity>(node);
     if (!entity)
     {
         return false;
@@ -1496,7 +1496,7 @@ bool VolumeEditorGizmo::OnMouseHover(const Handle<Camera>& camera, const MouseEv
 
 bool VolumeEditorGizmo::OnMouseLeave(const Handle<Camera>& camera, const MouseEvent& mouseEvent, const Handle<Node>& node)
 {
-    Entity* entity = ObjCast<Entity>(node);
+    Entity* entity = DynamicCast<Entity>(node);
     if (!entity)
     {
         return false;
@@ -2617,7 +2617,7 @@ void EditorSubsystem::StartWatchingNode(const Handle<Node>& node)
     UISubsystem* uiSubsystem = GetWorld()->GetSubsystem<UISubsystem>();
     AssertDebug(uiSubsystem != nullptr);
 
-    Handle<UIListView> listView = ObjCast<UIListView>(uiSubsystem->GetUIStage()->FindChildUIObject(NAME("Outline_ListView")));
+    Handle<UIListView> listView = DynamicCast<UIListView>(uiSubsystem->GetUIStage()->FindChildUIObject(NAME("Outline_ListView")));
     AssertDebug(listView.IsValid());
 
     //    m_editorDelegates->AddNodeWatcher(
@@ -2696,7 +2696,7 @@ void EditorSubsystem::StopWatchingNode(const Handle<Node>& node)
     UISubsystem* uiSubsystem = GetWorld()->GetSubsystem<UISubsystem>();
     AssertDebug(uiSubsystem != nullptr);
 
-    Handle<UIListView> listView = ObjCast<UIListView>(uiSubsystem->GetUIStage()->FindChildUIObject(NAME("Outline_ListView")));
+    Handle<UIListView> listView = DynamicCast<UIListView>(uiSubsystem->GetUIStage()->FindChildUIObject(NAME("Outline_ListView")));
     AssertDebug(listView.IsValid());
 
 
@@ -2714,7 +2714,7 @@ void EditorSubsystem::ClearWatchedNodes()
     UISubsystem* uiSubsystem = GetWorld()->GetSubsystem<UISubsystem>();
     AssertDebug(uiSubsystem != nullptr);
 
-    Handle<UIListView> listView = ObjCast<UIListView>(uiSubsystem->GetUIStage()->FindChildUIObject(NAME("Outline_ListView")));
+    Handle<UIListView> listView = DynamicCast<UIListView>(uiSubsystem->GetUIStage()->FindChildUIObject(NAME("Outline_ListView")));
     AssertDebug(listView.IsValid());
 
     if (const Handle<UIDataSourceBase>& dataSource = listView->GetDataSource())
@@ -2778,7 +2778,7 @@ void EditorSubsystem::InitActiveSceneSelection()
         return;
     }
 
-    Handle<UIMenuItem> activeSceneMenuItem = ObjCast<UIMenuItem>(activeSceneSelection);
+    Handle<UIMenuItem> activeSceneMenuItem = DynamicCast<UIMenuItem>(activeSceneSelection);
 
     if (!activeSceneMenuItem.IsValid())
     {
@@ -3118,7 +3118,7 @@ void EditorSubsystem::SetFocusedNode(const Handle<Node>& focusedNode, bool shoul
     {
         if (focusedNode->GetScene() != nullptr)
         {
-            if (Entity* entity = ObjCast<Entity>(focusedNode))
+            if (Entity* entity = DynamicCast<Entity>(focusedNode))
             {
                 entity->AddTag<EntityTag::FocusedInEditor>();
             }
@@ -3157,7 +3157,7 @@ void EditorSubsystem::SetFocusedNode(const Handle<Node>& focusedNode, bool shoul
 
     if (previousFocusedNode != nullptr)
     {
-        if (Entity* entity = ObjCast<Entity>(previousFocusedNode))
+        if (Entity* entity = DynamicCast<Entity>(previousFocusedNode))
         {
             entity->RemoveTag<EntityTag::FocusedInEditor>();
         }

--- a/Source/Engine/editor/EditorSubsystem.cpp
+++ b/Source/Engine/editor/EditorSubsystem.cpp
@@ -30,7 +30,6 @@
 #include <scene/System.hpp>
 #include <scene/systems/ScriptSystem.hpp>
 #include <scene/systems/MeshSystem.hpp>
-#include <scene/systems/editor/EditorSpriteSystem.hpp>
 
 #include <scene/sky/DynamicSkySystem.hpp>
 
@@ -1942,11 +1941,6 @@ void EditorSubsystem::OnAddedToWorld()
     if (!GetWorld()->GetSubsystem<UISubsystem>())
     {
         HYP_FAIL("EditorSubsystem requires UISubsystem to be initialized");
-    }
-
-    if (!GetWorld()->HasSystem<EditorSpriteSystem>())
-    {
-        GetWorld()->AddSystem(MakeHandle<EditorSpriteSystem>());
     }
 
     m_editorScene = MakeHandle<Scene>(NAME("EditorScene"), SceneFlags::FOREGROUND | SceneFlags::EDITOR);

--- a/Source/Engine/editor/EditorTask.cpp
+++ b/Source/Engine/editor/EditorTask.cpp
@@ -233,12 +233,12 @@ void EditorTaskScope::Reset(bool shouldCancel)
             return;
         }*/
 
-        if (TickableEditorTask* tickableEditorTask = ObjCast<TickableEditorTask>(m_task.Get()))
+        if (TickableEditorTask* tickableEditorTask = DynamicCast<TickableEditorTask>(m_task.Get()))
         {
             Mutex::Guard guard(tickableEditorTask->m_mutex);
             tickableEditorTask->isComplete = true;
         }
-        else if (LongRunningEditorTask* longRunningEditorTask = ObjCast<LongRunningEditorTask>(m_task.Get()))
+        else if (LongRunningEditorTask* longRunningEditorTask = DynamicCast<LongRunningEditorTask>(m_task.Get()))
         {
             longRunningEditorTask->GetTask().Await();
         }

--- a/Source/Engine/editor/EditorTaskManager.cpp
+++ b/Source/Engine/editor/EditorTaskManager.cpp
@@ -88,7 +88,7 @@ void EditorTaskManager::Tick()
             Assert(task->IsCommitted());
         }
 
-        if (TickableEditorTask* tickableTask = ObjCast<TickableEditorTask>(task.Get()))
+        if (TickableEditorTask* tickableTask = DynamicCast<TickableEditorTask>(task.Get()))
         {
             if (tickableTask->GetTimer().Waiting())
             {

--- a/Source/Engine/editor/commands/EditorCommands.cpp
+++ b/Source/Engine/editor/commands/EditorCommands.cpp
@@ -1163,7 +1163,7 @@ public:
         static const auto SetupWatch = [](UISubsystem* uiSubsystem, const AssetPath& path)
         {
             Handle<AssetObject> assetObject = GetCurrentAssetRegistry()->GetAssetFromPath(path.ToString());
-            Handle<Texture> texture = ObjCast<Texture>(assetObject);
+            Handle<Texture> texture = DynamicCast<Texture>(assetObject);
 
             if (!texture.IsValid())
             {
@@ -1210,7 +1210,7 @@ public:
                     if (!assetObject.IsValid())
                         return;
 
-                    Handle<Texture> texture = ObjCast<Texture>(assetObject);
+                    Handle<Texture> texture = DynamicCast<Texture>(assetObject);
                     if (!texture.IsValid())
                         return;
 

--- a/Source/Engine/engine/EngineDriver.cpp
+++ b/Source/Engine/engine/EngineDriver.cpp
@@ -21,7 +21,6 @@
 #include <engine/threads/VisThread.hpp>
 
 #include <rendering/PostFX.hpp>
-#include <rendering/RenderGroup.hpp>
 #include <rendering/RenderInterface.hpp>
 #include <rendering/GBuffer.hpp>
 #include <rendering/FinalPass.hpp>
@@ -149,7 +148,7 @@ static void UpdateInstancedMeshEntities(Scene* scene, Array<Entity*, AllocatorTy
             meshComponent.instanceData = AssetReference(imd);
         }
 
-        const Handle<InstancedMeshData>& imd = ObjCast<InstancedMeshData>(meshComponent.instanceData.Resolve());
+        const Handle<InstancedMeshData>& imd = DynamicCast<InstancedMeshData>(meshComponent.instanceData.Resolve());
 
         if (!imd.IsValid())
         {

--- a/Source/Engine/engine/threads/RenderThread.cpp
+++ b/Source/Engine/engine/threads/RenderThread.cpp
@@ -15,7 +15,6 @@
 #include <rendering/DebugDrawer.hpp>
 
 #include <rendering/PostFX.hpp>
-#include <rendering/RenderGroup.hpp>
 #include <rendering/RenderInterface.hpp>
 #include <rendering/GBuffer.hpp>
 #include <rendering/FinalPass.hpp>

--- a/Source/Engine/engine/threads/SimThread.cpp
+++ b/Source/Engine/engine/threads/SimThread.cpp
@@ -11,16 +11,14 @@
 #include <engine/EngineGlobals.hpp>
 #include <engine/EngineDriver.hpp>
 #include <engine/EngineStats.hpp>
+#include <engine/Game.hpp>
 
 #include <Core/threading/Threads.hpp>
+#include <Core/threading/ThreadSignal.hpp>
 
 #include <Core/math/MathUtil.hpp>
 
 #include <Core/cli/CommandLine.hpp>
-
-#include <engine/Game.hpp>
-#include <engine/EngineDriver.hpp>
-#include <engine/EngineGlobals.hpp>
 
 #include <system/AppContext.hpp>
 
@@ -55,6 +53,8 @@ extern const CommandLineArguments& GetCommandLineArguments();
 } // namespace CoreApi
 
 extern void DestroyDetachedScenes();
+
+extern ThreadSignal g_renderInitSignal;
 
 struct LaunchGameAsync
 {
@@ -211,10 +211,14 @@ void SimThread::operator()()
 #if HYP_SCRIPT
     HypScript::GetInstance().Initialize();
 #endif
+    
+    // Wait for render thread to be ready
+    g_renderInitSignal.Wait();
 
     // create fallback world
     Handle<World> defaultWorld = MakeHandle<World>(NAME("DefaultWorld"), WorldFlags::NONE);
     InitObject(defaultWorld);
+    
     g_engineDriver->SetDefaultWorld(defaultWorld);
 
     // Handle -SimulateOnMainThread

--- a/Source/Engine/game/DefaultGame.cpp
+++ b/Source/Engine/game/DefaultGame.cpp
@@ -87,11 +87,11 @@ void DefaultGame::OnLaunch_Impl()
 
         if (mainSceneAsset.IsValid())
         {
-            Handle<Scene> mainScene = ObjCast<Scene>(mainSceneAsset);
+            Handle<Scene> mainScene = DynamicCast<Scene>(mainSceneAsset);
             Assert(mainScene.IsValid(), "Could not find main scene asset");
             if (mainScene.IsValid())
             {
-                m_camera = ObjCast<Camera>(mainScene->GetRoot()->GetChild(0));
+                m_camera = DynamicCast<Camera>(mainScene->GetRoot()->GetChild(0));
                 Assert(m_camera.IsValid());
 
                 Vec2u viewportSize = Vec2u(m_camera->GetDimensions());

--- a/Source/Engine/rendering/Bindless.cpp
+++ b/Source/Engine/rendering/Bindless.cpp
@@ -66,11 +66,11 @@ void BindlessStorage::AddResource(BindlessStorageSlot slot, uint32 index, const 
         const DescriptorSetRef& descriptorSet = g_renderInterface->globalDescriptorTable->GetDescriptorSet(BindlessStorageSlotNames[slot], frameIndex);
         AssertDebug(descriptorSet.IsValid());
 
-        if (GpuImageView* imageView = ObjCast<GpuImageView>(resource.Get()))
+        if (GpuImageView* imageView = DynamicCast<GpuImageView>(resource.Get()))
         {
             descriptorSet->SetElement(BindlessStorageDescriptorNames[slot], index, imageView);
         }
-        else if (GpuBuffer* buffer = ObjCast<GpuBuffer>(resource.Get()))
+        else if (GpuBuffer* buffer = DynamicCast<GpuBuffer>(resource.Get()))
         {
             descriptorSet->SetElement(BindlessStorageDescriptorNames[slot], index, buffer);
         }

--- a/Source/Engine/rendering/Bindless.cpp
+++ b/Source/Engine/rendering/Bindless.cpp
@@ -97,7 +97,15 @@ void BindlessStorage::RemoveResource(BindlessStorageSlot slot, uint32 index)
         const DescriptorSetRef& descriptorSet = g_renderInterface->globalDescriptorTable->GetDescriptorSet(BindlessStorageSlotNames[slot], frameIndex);
         AssertDebug(descriptorSet.IsValid());
 
-        descriptorSet->DeleteElement(BindlessStorageDescriptorNames[slot], index);
+        if (slot == BindlessStorage_Textures)
+        {
+            GpuImageView* placeholder_view = g_renderInterface->placeholderData->GetImageView2D1x1R8();
+            descriptorSet->SetElement(BindlessStorageDescriptorNames[slot], index, placeholder_view);
+        }
+        else
+        {
+            descriptorSet->DeleteElement(BindlessStorageDescriptorNames[slot], index);
+        }
     }
 
     resources.EraseAt(index);

--- a/Source/Engine/rendering/CommandRecorder.cpp
+++ b/Source/Engine/rendering/CommandRecorder.cpp
@@ -17,7 +17,6 @@
 #include <rendering/ShaderInstance.hpp>
 #include <rendering/Shader.hpp>
 #include <rendering/Mesh.hpp>
-#include <rendering/RenderGroup.hpp>
 
 #include <rendering/RayTracingPipeline.hpp>
 #include <rendering/AccelerationStructure.hpp>

--- a/Source/Engine/rendering/CommandRecorder.hpp
+++ b/Source/Engine/rendering/CommandRecorder.hpp
@@ -562,6 +562,57 @@ private:
     ImageSubResource dstSubResource;
 };
 
+class FillImage final : public CmdBase
+{
+public:
+    FillImage(GpuImage* image, float value)
+        : m_image(image),
+          m_value(value),
+          m_offset(Vec3u::Zero()),
+          m_extent(image ? image->GetTextureDesc().extent : Vec3u::One())
+    {
+    }
+
+    FillImage(GpuImage* image, float value, const ImageSubResource& subResource)
+        : m_image(image),
+          m_value(value),
+          m_subResource(subResource),
+          m_offset(Vec3u::Zero()),
+          m_extent(image ? image->GetTextureDesc().extent : Vec3u::One())
+    {
+    }
+
+    FillImage(GpuImage* image, float value, const ImageSubResource& subResource, const Vec3u& offset, const Vec3u& extent)
+        : m_image(image),
+          m_value(value),
+          m_subResource(subResource),
+          m_offset(offset),
+          m_extent(extent)
+    {
+    }
+
+    static inline void InvokeStatic(CmdBase* cmd, CommandBuffer* commandBuffer)
+    {
+        FillImage* cmdCasted = static_cast<FillImage*>(cmd);
+
+        cmdCasted->m_image->Fill(
+            commandBuffer,
+            cmdCasted->m_value,
+            cmdCasted->m_subResource,
+            cmdCasted->m_offset,
+            cmdCasted->m_extent);
+
+        static_assert(std::is_trivially_destructible_v<FillImage>);
+    }
+
+private:
+    GpuImage* m_image;
+    float m_value;
+    ImageSubResource m_subResource;
+    Vec3u m_offset;
+    Vec3u m_extent;
+};
+
 class CopyImageToBuffer final : public CmdBase
 {
 public:

--- a/Source/Engine/rendering/DDGI.cpp
+++ b/Source/Engine/rendering/DDGI.cpp
@@ -280,7 +280,7 @@ void DDGI::Render(Frame* frame, const RenderSetup& renderSetup)
 
     UpdateUniforms(frame, renderSetup);
 
-    RayTracingPassData* pd = ObjCast<RayTracingPassData>(renderSetup.passData);
+    RayTracingPassData* pd = DynamicCast<RayTracingPassData>(renderSetup.passData);
     Assert(pd != nullptr);
 
     const uint32 frameIndex = frame->GetFrameIndex();

--- a/Source/Engine/rendering/DebugDrawer.cpp
+++ b/Source/Engine/rendering/DebugDrawer.cpp
@@ -8,7 +8,6 @@
 
 #include <rendering/DebugDrawer.hpp>
 #include <rendering/RenderInterface.hpp>
-#include <rendering/RenderGroup.hpp>
 #include <rendering/GBuffer.hpp>
 #include <rendering/ShaderManager.hpp>
 #include <rendering/GraphicsPipelineCache.hpp>
@@ -758,7 +757,7 @@ void DebugDrawer::Render(Frame* frame, const RenderSetup& renderSetup)
         cr << SetFaceCullMode(FCM_BACK);    
     });
     
-    DeferredRendererPassData* dpd = ObjCast<DeferredRendererPassData>(renderSetup.passData);
+    DeferredRendererPassData* dpd = DynamicCast<DeferredRendererPassData>(renderSetup.passData);
     AssertDebug(dpd != nullptr);
     
     cr << SetShaderUniform(0, "SamplerNearest"_sh, g_renderInterface->placeholderData->GetSamplerNearest());

--- a/Source/Engine/rendering/DebugDrawer.cpp
+++ b/Source/Engine/rendering/DebugDrawer.cpp
@@ -674,7 +674,6 @@ void DebugDrawer::Render(Frame* frame, const RenderSetup& renderSetup)
     const uint32 frameIndex = frame->GetFrameIndex();
 
     GpuBufferRef& instanceBuffer = m_instanceBuffers[frameIndex];
-    bool wasInstanceBufferRebuilt = false;
 
     if (!instanceBuffer || m_headers[idx].Size() * sizeof(ImmediateDrawShaderData) > instanceBuffer->Size())
     {

--- a/Source/Engine/rendering/DrawCall.hpp
+++ b/Source/Engine/rendering/DrawCall.hpp
@@ -29,6 +29,7 @@ class MaterialInstance;
 class Skeleton;
 class Entity;
 class RenderProxyMesh;
+class RenderProxySprite;
 struct DrawCommandData;
 class IndirectDrawState;
 struct InstanceData;

--- a/Source/Engine/rendering/DrawCall.hpp
+++ b/Source/Engine/rendering/DrawCall.hpp
@@ -321,7 +321,9 @@ struct DrawCallCollection
     RenderableAttributeSet attributes;
     EnumFlags<RenderGroupFlags> flags = {};
     ParallelRenderingState* parallelRenderingState = nullptr;
-    bool isInit = false;
+    
+    bool isInit : 1 = false;
+    bool suppressStats : 1 = false;
 
     // map entity id to mesh proxy
     IndirectRenderer* indirectRenderer = nullptr;

--- a/Source/Engine/rendering/FinalPass.cpp
+++ b/Source/Engine/rendering/FinalPass.cpp
@@ -20,6 +20,7 @@
 
 #include <rendering/renderers/DeferredRenderer.hpp>
 #include <rendering/renderers/UIRenderer.hpp>
+#include <rendering/renderers/SpriteRenderer.hpp>
 
 #include <rendering/util/DeletionQueue.hpp>
 
@@ -172,6 +173,27 @@ void FinalPass::Render(Frame* frame, const RenderSetup& rs)
             }
         }
     }
+
+#if HYP_EDITOR
+    {
+        SpriteRenderer* spriteRenderer = static_cast<SpriteRenderer*>(g_renderInterface->globalRenderers[GRT_SPRITE][0]);
+
+        if (spriteRenderer != nullptr)
+        {
+            for (World* world : GetActiveWorlds())
+            {
+                for (View* view : world->GetViews())
+                {
+                    RenderSetup currentViewSetup = rs.Fork();
+                    currentViewSetup.world = world;
+                    currentViewSetup.view = view;
+
+                    spriteRenderer->RenderFrame(frame, currentViewSetup);
+                }
+            }
+        }
+    }
+#endif
 
     cr << SetCurrentFramebuffer(nullptr);
 

--- a/Source/Engine/rendering/FinalPass.cpp
+++ b/Source/Engine/rendering/FinalPass.cpp
@@ -20,7 +20,6 @@
 
 #include <rendering/renderers/DeferredRenderer.hpp>
 #include <rendering/renderers/UIRenderer.hpp>
-#include <rendering/renderers/SpriteRenderer.hpp>
 
 #include <rendering/util/DeletionQueue.hpp>
 
@@ -173,27 +172,6 @@ void FinalPass::Render(Frame* frame, const RenderSetup& rs)
             }
         }
     }
-
-#if HYP_EDITOR
-    {
-        SpriteRenderer* spriteRenderer = static_cast<SpriteRenderer*>(g_renderInterface->globalRenderers[GRT_SPRITE][0]);
-
-        if (spriteRenderer != nullptr)
-        {
-            for (World* world : GetActiveWorlds())
-            {
-                for (View* view : world->GetViews())
-                {
-                    RenderSetup currentViewSetup = rs.Fork();
-                    currentViewSetup.world = world;
-                    currentViewSetup.view = view;
-
-                    spriteRenderer->RenderFrame(frame, currentViewSetup);
-                }
-            }
-        }
-    }
-#endif
 
     cr << SetCurrentFramebuffer(nullptr);
 

--- a/Source/Engine/rendering/FinalPass.cpp
+++ b/Source/Engine/rendering/FinalPass.cpp
@@ -9,7 +9,6 @@
 #include <rendering/FinalPass.hpp>
 #include <rendering/ShaderManager.hpp>
 #include <rendering/FullScreenPass.hpp>
-#include <rendering/RenderGroup.hpp>
 #include <rendering/PlaceholderData.hpp>
 #include <rendering/GBuffer.hpp>
 #include <rendering/RenderInterface.hpp>

--- a/Source/Engine/rendering/FullScreenPass.cpp
+++ b/Source/Engine/rendering/FullScreenPass.cpp
@@ -8,7 +8,6 @@
 
 #include <rendering/FullScreenPass.hpp>
 #include <rendering/ShaderManager.hpp>
-#include <rendering/RenderGroup.hpp>
 #include <rendering/GBuffer.hpp>
 #include <rendering/TemporalBlending.hpp>
 #include <rendering/GraphicsPipelineCache.hpp>

--- a/Source/Engine/rendering/FullScreenPass.cpp
+++ b/Source/Engine/rendering/FullScreenPass.cpp
@@ -692,7 +692,7 @@ void FullScreenPass::Begin(Frame* frame, const RenderSetup& renderSetup)
 
     cr << SetInputLayout(StaticVertexInputLayout<VT_Simple>);
     cr << SetTopology(TOP_TRIANGLES);
-    
+
     cr << SetCurrentShader(m_shaderDesc);
 
     cr << SetDepthTest(false);

--- a/Source/Engine/rendering/FullScreenPass.hpp
+++ b/Source/Engine/rendering/FullScreenPass.hpp
@@ -131,7 +131,8 @@ public:
     virtual void Create();
 
     virtual void Render(Frame* frame, const RenderSetup& renderSetup);
-    void RenderToFramebuffer(Frame* frame, const RenderSetup& renderSetup, Framebuffer* framebuffer);
+    virtual void RenderToFramebuffer(Frame* frame, const RenderSetup& renderSetup, Framebuffer* framebuffer) final;
+    
     void RenderFullScreenQuad(Frame* frame, const RenderSetup& renderSetup);
 
     void Begin(Frame* frame, const RenderSetup& renderSetup);

--- a/Source/Engine/rendering/GBuffer.cpp
+++ b/Source/Engine/rendering/GBuffer.cpp
@@ -7,7 +7,6 @@
 #include <RenderingPch.hpp>
 
 #include <rendering/GBuffer.hpp>
-#include <rendering/RenderGroup.hpp>
 #include <rendering/RenderInterface.hpp>
 #include <rendering/Swapchain.hpp>
 

--- a/Source/Engine/rendering/GpuImage.hpp
+++ b/Source/Engine/rendering/GpuImage.hpp
@@ -214,6 +214,13 @@ public:
         GpuBuffer* dstBuffer,
         const ImageSubResource& subResource) const = 0;
 
+    virtual void Fill(
+        CommandBuffer* commandBuffer,
+        float value,
+        const ImageSubResource& subResource,
+        const Vec3u& offset = Vec3u::Zero(),
+        const Vec3u& extent = Vec3u::One()) = 0;
+
     virtual void CopyFrom(
         CommandBuffer* commandBuffer,
         const GpuImage* srcImage,

--- a/Source/Engine/rendering/GpuImageView.hpp
+++ b/Source/Engine/rendering/GpuImageView.hpp
@@ -34,7 +34,7 @@ public:
     {
         m_debugName = name;
     }
-#endif
+#endif // HYP_DEBUG_MODE
 
     HYP_FORCE_INLINE const GpuImageRef& GetImage() const
     {

--- a/Source/Engine/rendering/IndirectDraw.cpp
+++ b/Source/Engine/rendering/IndirectDraw.cpp
@@ -457,7 +457,7 @@ void IndirectRenderer::ExecuteCullShaderInBatches(Frame* frame, const RenderSetu
         m_cachedCullDataUpdatedBits = 0xFF;
     }
 
-    DeferredRendererPassData* pd = ObjCast<DeferredRendererPassData>(renderSetup.passData);
+    DeferredRendererPassData* pd = DynamicCast<DeferredRendererPassData>(renderSetup.passData);
     AssertDebug(pd != nullptr);
 
     uint32 numShaderUniforms = 0;

--- a/Source/Engine/rendering/Mesh.cpp
+++ b/Source/Engine/rendering/Mesh.cpp
@@ -164,22 +164,27 @@ void Mesh::SetIndexData(Span<const ubyte> indexData)
 
 void Mesh::PageBlobData()
 {
+    if (IsTransient() || !IsRegistered())
+    {
+        return;
+    }
+
+    Handle<AssetRegistry> registry = GetAssetRegistry();
+    AssertDebug(registry.IsValid());
+
+    if (!registry.IsValid())
+    {
+        return;
+    }
+
+    bool needsSaveBlobData = false;
+
+    BlobStorage* blobStorage = registry->HasBlobStorage() ? &registry->GetBlobStorage() : nullptr;
+
     if (m_vertexData.raw == nullptr
         && m_vertexData.key
         && m_vertexData.size != 0)
     {
-        Handle<AssetRegistry> registry = GetAssetRegistry();
-        AssertDebug(registry.IsValid());
-
-        if (!registry.IsValid())
-        {
-            return;
-        }
-
-        bool needsSaveBlobData = false;
-
-        BlobStorage* blobStorage = registry->HasBlobStorage() ? &registry->GetBlobStorage() : nullptr;
-
         if (!blobStorage || !blobStorage->GetData(m_vertexData.key, m_vertexData.size, m_vertexData.raw))
         {
             ([&]()
@@ -238,54 +243,57 @@ void Mesh::PageBlobData()
         {
             m_indexData.readOnly = true;
         }
-
-        if (m_bvhData.raw == nullptr && m_bvhData.key && m_bvhData.size != 0)
+    }
+    
+    // Keep BVH data separate from vertex and index data because it is mutually exclusive from them
+    if (m_bvhData.raw == nullptr
+        && m_bvhData.key
+        && m_bvhData.size != 0)
+    {
+        if (!blobStorage || !blobStorage->GetData(m_bvhData.key, m_bvhData.size, m_bvhData.raw))
         {
-            if (!blobStorage || !blobStorage->GetData(m_bvhData.key, m_bvhData.size, m_bvhData.raw))
-            {
-                ([&]()
-                    {
+            ([&]()
+                {
 #if HYP_EDITOR || HYP_ALLOW_INLINE_BLOBS
-                        FileByteReader stream { registry->GetRootPath() / AssetBuckets::Meshes.GetName() / (String(*GetName()) + ".BVH.raw.blob") };
-                        if (!stream.Eof())
-                        {
-                            ByteBuffer buffer = stream.Read(stream.Max());
+                    FileByteReader stream { registry->GetRootPath() / AssetBuckets::Meshes.GetName() / (String(*GetName()) + ".BVH.raw.blob") };
+                    if (!stream.Eof())
+                    {
+                        ByteBuffer buffer = stream.Read(stream.Max());
 
-                            AllocateBlobData(m_bvhData, buffer.Data(), buffer.Size(), alignof(uint32));
+                        AllocateBlobData(m_bvhData, buffer.Data(), buffer.Size(), alignof(uint32));
 
-                            needsSaveBlobData = true;
+                        needsSaveBlobData = true;
 
-                            MarkDirty();
+                        MarkDirty();
 
-                            return;
-                        }
+                        return;
+                    }
 #endif
                         
-                        HYP_FAIL("Blob data missing! Data corruption detected.");
-                    })();
-            }
-            else
-            {
-                m_bvhData.readOnly = true;
-            }
-
-            if (m_bvhData.raw != nullptr)
-            {
-                BVHNode::Deserialize(m_bvh, m_bvhData.raw, m_bvhData.size);
-            }
+                    HYP_FAIL("Blob data missing! Data corruption detected.");
+                })();
         }
+        else
+        {
+            m_bvhData.readOnly = true;
+        }
+
+        if (m_bvhData.raw != nullptr)
+        {
+            BVHNode::Deserialize(m_bvh, m_bvhData.raw, m_bvhData.size);
+        }
+    }
 
 #if HYP_EDITOR
-        if (needsSaveBlobData)
+    if (needsSaveBlobData)
+    {
+        Result saveBlobDataResult = SaveBlobData(blobStorage);
+        if (saveBlobDataResult.HasError())
         {
-            Result saveBlobDataResult = SaveBlobData(blobStorage);
-            if (saveBlobDataResult.HasError())
-            {
-                HYP_LOG(Assets, Error, "Failed to save local blob data: {}", saveBlobDataResult.GetError().GetMessage());
-            }
+            HYP_LOG(Assets, Error, "Failed to save local blob data: {}", saveBlobDataResult.GetError().GetMessage());
         }
-#endif
     }
+#endif
 }
 
 void Mesh::UnpageBlobData()

--- a/Source/Engine/rendering/Mesh.hpp
+++ b/Source/Engine/rendering/Mesh.hpp
@@ -221,7 +221,6 @@ protected:
 
         if (m_bvhData.size != 0)
         {
-            AssertDebug(m_bvhData.raw != nullptr);
             outReferences.EmplaceBack("BVH", 1, &m_bvhData);
         }
     }

--- a/Source/Engine/rendering/PlaceholderData.cpp
+++ b/Source/Engine/rendering/PlaceholderData.cpp
@@ -217,7 +217,7 @@ void PlaceholderData::Initialize()
     {
         if (Handle<AssetObject> asset = GetEngineAssetRegistry()->GetAsset(AssetBuckets::Textures, name); asset.IsValid())
         {
-            Handle<Texture> textureAsset = ObjCast<Texture>(asset);
+            Handle<Texture> textureAsset = DynamicCast<Texture>(asset);
             Assert(textureAsset != nullptr);
 
             textureAsset->SetPersistentRequested(true, /* setFlag */ true);

--- a/Source/Engine/rendering/RayTracingReflections.cpp
+++ b/Source/Engine/rendering/RayTracingReflections.cpp
@@ -94,7 +94,7 @@ void RayTracingReflections::Render(Frame* frame, const RenderSetup& renderSetup)
 
     AssertDebug(renderSetup.world && renderSetup.view);
 
-    RayTracingPassData* pd = ObjCast<RayTracingPassData>(renderSetup.passData);
+    RayTracingPassData* pd = DynamicCast<RayTracingPassData>(renderSetup.passData);
     AssertDebug(pd != nullptr);
 
     DeferredRendererPassData* parentPass = pd->parentPass;

--- a/Source/Engine/rendering/RenderCollection.cpp
+++ b/Source/Engine/rendering/RenderCollection.cpp
@@ -403,7 +403,7 @@ static inline void ForEachResourceTracker(Span<ResourceTrackerBase<AllocatorType
 template <class AllocatorType, class ElementType, class ProxyType>
 static inline void UpdateRefs_Impl(ResourceTracker<AllocatorType, ObjId<ElementType>, ElementType*, ProxyType>& resourceTracker)
 {
-    auto diff = resourceTracker.GetDiff();
+    const ResourceTrackerDiff& diff = resourceTracker.GetDiff();
     if (!diff.NeedsUpdate())
     {
         return;
@@ -448,7 +448,7 @@ static inline void UpdateRefs_Impl(ResourceTracker<AllocatorType, ObjId<ElementT
         Array<ObjId<ElementType>> changedIds;
         resourceTracker.GetChanged(changedIds);
 
-        for (const ObjId<ElementType>& id : changedIds)
+        for (const ObjId<ElementType> id : changedIds)
         {
             ElementType** ppResource = resourceTracker.GetElement(id);
             AssertDebug(ppResource && *ppResource);
@@ -712,8 +712,6 @@ static void SetForwardShadingUniforms(
     cr << SetShaderUniform(numShaderUniforms++, "FowardShadingConstants"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
 }
 
-HYP_DISABLE_OPTIMIZATION;
-
 template <bool UseIndirectRendering, class TCommandRecorder>
 static void RenderAll(
     Frame* frame,
@@ -783,7 +781,7 @@ static void RenderAll(
     // }
 
     // Will only be non-null if we are in a deferred rendering pass.
-    DeferredRendererPassData* dpd = ObjCast<DeferredRendererPassData>(renderSetup.passData);
+    DeferredRendererPassData* dpd = DynamicCast<DeferredRendererPassData>(renderSetup.passData);
 
     if (dpd != nullptr)
     {
@@ -977,8 +975,6 @@ static void RenderAll(
     }
 }
 
-HYP_ENABLE_OPTIMIZATION;
-
 template <class TCommandRecorder>
 static void PerformRenderingImpl(
     Frame* frame,
@@ -993,7 +989,7 @@ static void PerformRenderingImpl(
         && drawCallCollection.flags[RenderGroupFlags::INDIRECT_RENDERING]
         && (renderSetup.passData && renderSetup.passData->cullData.depthPyramidImageView);
 
-    DeferredRendererPassData* dpd = ObjCast<DeferredRendererPassData>(renderSetup.passData);
+    DeferredRendererPassData* dpd = DynamicCast<DeferredRendererPassData>(renderSetup.passData);
     // Not env probes or anything like that
     const bool isNormalDrawingPass = dpd != nullptr;
 

--- a/Source/Engine/rendering/RenderCollection.cpp
+++ b/Source/Engine/rendering/RenderCollection.cpp
@@ -878,8 +878,11 @@ static void RenderAll(
 
         prevMesh = meshProxy.mesh;
 
-        g_statDrawCalls++;
-        g_statTriangles += meshProxy.numIndices / 3;
+        if (!drawCallCollection.suppressStats)
+        {
+            g_statDrawCalls++;
+            g_statTriangles += meshProxy.numIndices / 3;
+        }
     }
 
     const InstancedDrawCallStorage& instancedDrawCalls = drawCallCollection.instancedDrawCalls;
@@ -966,8 +969,11 @@ static void RenderAll(
         prevMesh = meshProxy.mesh;
             
         // @NOTE For indirect rendering we would need to read back the number of drawn instances from the GPU to get correct stats.
-        g_statInstancedDrawCalls += entityInstanceBatch->numEntities;
-        g_statTriangles += meshProxy.numIndices / 3;
+        if (!drawCallCollection.suppressStats)
+        {
+            g_statInstancedDrawCalls += entityInstanceBatch->numEntities;
+            g_statTriangles += meshProxy.numIndices / 3;
+        }
     }
 }
 

--- a/Source/Engine/rendering/RenderCollection.cpp
+++ b/Source/Engine/rendering/RenderCollection.cpp
@@ -45,6 +45,7 @@
 #include <scene/FogVolume.hpp>
 #include <scene/ParticleVolume.hpp>
 #include <scene/LightmapVolume.hpp>
+#include <scene/Sprite.hpp>
 
 #include <scene/camera/Camera.hpp>
 

--- a/Source/Engine/rendering/RenderInterface.cpp
+++ b/Source/Engine/rendering/RenderInterface.cpp
@@ -53,6 +53,7 @@
 #include <rendering/renderers/DeferredRenderer.hpp>
 #include <rendering/renderers/ShadowRenderer.hpp>
 #include <rendering/renderers/ParticleVolumeRenderer.hpp>
+#include <rendering/renderers/SpriteRenderer.hpp>
 #include <rendering/renderers/UIRenderer.hpp>
 
 #include <rendering/shadows/ShadowMapCache.hpp>
@@ -700,6 +701,11 @@ RendererResult RenderInterface::Initialize()
     // one global particle volume renderer
     globalRenderers[GRT_PARTICLE_VOLUME].ResizeZeroed(1);
     globalRenderers[GRT_PARTICLE_VOLUME][0] = new ParticleVolumeRenderer;
+
+    // one global sprite renderer
+    globalRenderers[GRT_SPRITE].ResizeZeroed(1);
+    globalRenderers[GRT_SPRITE][0] = new SpriteRenderer;
+    globalRenderers[GRT_SPRITE][0]->Initialize();
 
     return {};
 }

--- a/Source/Engine/rendering/RenderInterface.cpp
+++ b/Source/Engine/rendering/RenderInterface.cpp
@@ -44,10 +44,8 @@
 #include <rendering/StructuredBufferAllocator.hpp>
 
 #include <engine/resources/ResourceTracker.hpp>
-#include <rendering/util/DeletionQueue.hpp>
-#include <rendering/util/ShaderPropertyDictionary.hpp>
-#include <rendering/util/ShaderCompiler.hpp>
 #include <engine/resources/ResourceBinder.hpp>
+#include <rendering/resources/ResourceBindings.hpp>
 
 #include <rendering/renderers/EnvProbeRenderer.hpp>
 #include <rendering/renderers/DeferredRenderer.hpp>
@@ -58,7 +56,9 @@
 
 #include <rendering/shadows/ShadowMapCache.hpp>
 
-#include <rendering/resources/ResourceBindings.hpp>
+#include <rendering/util/DeletionQueue.hpp>
+#include <rendering/util/ShaderPropertyDictionary.hpp>
+#include <rendering/util/ShaderCompiler.hpp>
 
 #include <scene/View.hpp>
 #include <scene/World.hpp>
@@ -69,6 +69,7 @@
 #include <scene/FogVolume.hpp>
 #include <scene/LightmapVolume.hpp>
 #include <scene/Sprite.hpp>
+#include <scene/TextSprite.hpp>
 
 #include <scene/animation/Skeleton.hpp>
 
@@ -1997,6 +1998,7 @@ DECLARE_RENDER_DATA_CONTAINER(ParticleVolume, RenderProxyParticleVolume, NamedBu
 DECLARE_RENDER_DATA_CONTAINER(FogVolume, RenderProxyFogVolume, NamedBuffer::Invalid, nullptr, &s_fogVolumeBinder);
 
 DECLARE_RENDER_DATA_CONTAINER(Sprite, RenderProxySprite, NamedBuffer::Invalid, nullptr, &s_spriteBinder);
+DECLARE_RENDER_DATA_CONTAINER(TextSprite, RenderProxySprite, NamedBuffer::Invalid, nullptr, &s_spriteBinder);
 
 DECLARE_RENDER_DATA_CONTAINER(MaterialInstance, RenderProxyMaterial, NamedBuffer::Materials, nullptr, &s_materialBinder);
 

--- a/Source/Engine/rendering/RenderInterface.cpp
+++ b/Source/Engine/rendering/RenderInterface.cpp
@@ -67,6 +67,7 @@
 #include <scene/ParticleVolume.hpp>
 #include <scene/FogVolume.hpp>
 #include <scene/LightmapVolume.hpp>
+#include <scene/Sprite.hpp>
 
 #include <scene/animation/Skeleton.hpp>
 
@@ -1988,6 +1989,8 @@ DECLARE_RENDER_DATA_CONTAINER(LightmapVolume, RenderProxyLightmapVolume, NamedBu
 
 DECLARE_RENDER_DATA_CONTAINER(ParticleVolume, RenderProxyParticleVolume, NamedBuffer::Invalid, nullptr, &s_particleVolumeBinder);
 DECLARE_RENDER_DATA_CONTAINER(FogVolume, RenderProxyFogVolume, NamedBuffer::Invalid, nullptr, &s_fogVolumeBinder);
+
+DECLARE_RENDER_DATA_CONTAINER(Sprite, RenderProxySprite, NamedBuffer::Invalid, nullptr, &s_spriteBinder);
 
 DECLARE_RENDER_DATA_CONTAINER(MaterialInstance, RenderProxyMaterial, NamedBuffer::Materials, nullptr, &s_materialBinder);
 

--- a/Source/Engine/rendering/RenderInterface.cpp
+++ b/Source/Engine/rendering/RenderInterface.cpp
@@ -20,7 +20,6 @@
 #include <rendering/CommandRecorder.hpp>
 #include <rendering/RenderProxyList.hpp>
 #include <rendering/RenderProxy.hpp>
-#include <rendering/RenderGroup.hpp>
 #include <rendering/AsyncCompute.hpp>
 #include <rendering/Bindless.hpp>
 #include <rendering/Texture.hpp>

--- a/Source/Engine/rendering/RenderInterface.hpp
+++ b/Source/Engine/rendering/RenderInterface.hpp
@@ -153,6 +153,7 @@ enum GlobalRendererType : uint32
     GRT_ENV_GRID,        //!< Global renderer instance for EnvGrids
     GRT_SHADOW_MAP,      //!< Shadow map renderers, e.g. PointLightShadowRenderer, DirectionalLightShadowRenderer
     GRT_PARTICLE_VOLUME, //!< Global renderer instance for ParticleVolumes
+    GRT_SPRITE,          //!< Sprite rendering for editor sprites
 
     GRT_SSAO,
 

--- a/Source/Engine/rendering/RenderProxy.hpp
+++ b/Source/Engine/rendering/RenderProxy.hpp
@@ -35,6 +35,7 @@ class EnvProbe;
 class EnvGrid;
 class ShadowMap;
 class InstancedMeshData;
+class Sprite;
 
 enum AtlasTextureType : uint32;
 
@@ -368,6 +369,27 @@ public:
     WeakHandle<Camera> camera;
     CameraShaderData bufferData {};
     Frustum viewFrustum;
+};
+
+struct alignas(16) SpriteShaderData
+{
+    Vec4f positionSize;
+    Vec4f color;
+
+    uint32 spriteType;
+    float opacity;
+    uint32 textureIndex;
+    uint32 alwaysFaceCamera;
+
+    Vec4f _pad0;
+};
+
+class RenderProxySprite final : public IRenderProxy
+{
+public:
+    WeakHandle<class Sprite> sprite;
+    Texture* texture = nullptr;
+    SpriteShaderData bufferData {};
 };
 
 struct ProbeRayData

--- a/Source/Engine/rendering/RenderProxy.hpp
+++ b/Source/Engine/rendering/RenderProxy.hpp
@@ -389,6 +389,11 @@ class RenderProxySprite final : public IRenderProxy
 public:
     WeakHandle<class Sprite> sprite;
     Texture* texture = nullptr;
+    class FontAtlas* fontAtlas = nullptr;
+    String text;
+    Color textColor;
+    float textSize;
+    BoundingBox textAabb;
     SpriteShaderData bufferData {};
 };
 

--- a/Source/Engine/rendering/RenderProxyList.hpp
+++ b/Source/Engine/rendering/RenderProxyList.hpp
@@ -37,6 +37,7 @@ class FogVolume;
 class MaterialInstance;
 class Texture;
 class Skeleton;
+class Sprite;
 
 struct RenderProxyCamera;
 struct RenderProxyMesh;
@@ -48,6 +49,7 @@ struct RenderProxyParticleVolume;
 struct RenderProxyFogVolume;
 struct RenderProxyMaterial;
 struct RenderProxySkeleton;
+struct RenderProxySprite;
 
 HYP_MAKE_HAS_METHOD(UpdateRenderProxy);
 
@@ -79,7 +81,8 @@ public:
         FogVolume,
         MaterialInstance,
         Skeleton,
-        Texture>;
+        Texture,
+        Sprite>;
 
     using ResourceTrackerTypes = Tuple<
         ResourceTracker<AllocatorType, ObjId<Entity>, Entity*, RenderProxyMesh>,
@@ -93,7 +96,8 @@ public:
         ResourceTracker<AllocatorType, ObjId<FogVolume>, FogVolume*, RenderProxyFogVolume>,
         ResourceTracker<AllocatorType, ObjId<MaterialInstance>, MaterialInstance*, RenderProxyMaterial>,
         ResourceTracker<AllocatorType, ObjId<Skeleton>, Skeleton*, RenderProxySkeleton>,
-        ResourceTracker<AllocatorType, ObjId<Texture>, Texture*>>;
+        ResourceTracker<AllocatorType, ObjId<Texture>, Texture*>,
+        ResourceTracker<AllocatorType, ObjId<Sprite>, Sprite*, RenderProxySprite>>;
 
     static_assert(TupleSize<ResourceTrackerTypes>::value == TupleSize<TrackedResourceTypes>::value, "Tuple sizes must match");
 
@@ -176,6 +180,7 @@ public:
     DEF_RESOURCE_TRACKER_GETTER(Materials, MaterialInstance);
     DEF_RESOURCE_TRACKER_GETTER(Skeletons, Skeleton);
     DEF_RESOURCE_TRACKER_GETTER(Textures, Texture);
+    DEF_RESOURCE_TRACKER_GETTER(Sprites, Sprite);
 
 #undef DEF_RESOURCE_TRACKER_GETTER
 

--- a/Source/Engine/rendering/SSGI.cpp
+++ b/Source/Engine/rendering/SSGI.cpp
@@ -204,7 +204,7 @@ void SSGI::Render(Frame* frame, const RenderSetup& renderSetup)
 
     const uint32 frameIndex = frame->GetFrameIndex();
 
-    DeferredRendererPassData* dpd = ObjCast<DeferredRendererPassData>(renderSetup.passData);
+    DeferredRendererPassData* dpd = DynamicCast<DeferredRendererPassData>(renderSetup.passData);
     AssertDebug(dpd != nullptr);
 
     const FramebufferRef& inputsFramebuffer = dpd->view.GetUnsafe()->GetOutputTarget().GetFramebuffer(RenderBucket::Opaque);

--- a/Source/Engine/rendering/Texture.cpp
+++ b/Source/Engine/rendering/Texture.cpp
@@ -15,6 +15,7 @@
 #include <rendering/Frame.hpp>
 #include <rendering/PlaceholderData.hpp>
 #include <rendering/RenderHelpers.hpp>
+#include <rendering/TextureViewCache.hpp>
 
 #include <rendering/util/DeletionQueue.hpp>
 
@@ -276,7 +277,11 @@ Texture::~Texture()
     LockWriter(/* doInitialize */ false);
 
     if (m_gpuImage.IsValid())
+    {
         EnqueueDeletion(std::move(m_gpuImage));
+
+        g_renderInterface->textureViewCache->RemoveTexture(this);
+    }
 
     FreeBlobData(m_imageData);
 }

--- a/Source/Engine/rendering/Texture.cpp
+++ b/Source/Engine/rendering/Texture.cpp
@@ -278,9 +278,9 @@ Texture::~Texture()
 
     if (m_gpuImage.IsValid())
     {
-        EnqueueDeletion(std::move(m_gpuImage));
-
         g_renderInterface->textureViewCache->RemoveTexture(this);
+
+        EnqueueDeletion(std::move(m_gpuImage));
     }
 
     FreeBlobData(m_imageData);

--- a/Source/Engine/rendering/TextureViewCache.hpp
+++ b/Source/Engine/rendering/TextureViewCache.hpp
@@ -39,6 +39,7 @@ public:
         TextureType viewTextureType) = 0;
 
     virtual void RemoveTexture(const Texture* texture) = 0;
+
     virtual void CleanupUnusedTextures() = 0;
 };
 

--- a/Source/Engine/rendering/dx12/DX12DescriptorSet.cpp
+++ b/Source/Engine/rendering/dx12/DX12DescriptorSet.cpp
@@ -250,7 +250,7 @@ void DX12DescriptorSet::Update(bool force)
     //                continue;
     //            }
 
-    //            const DX12GpuBufferRef& ref = ObjCast<DX12GpuBuffer>(valuesIt.second);
+    //            const DX12GpuBufferRef& ref = DynamicCast<DX12GpuBuffer>(valuesIt.second);
     //            if (!ref.IsValid() || !ref->IsCreated())
     //            {
     //                continue;
@@ -301,7 +301,7 @@ void DX12DescriptorSet::Update(bool force)
     //                continue;
     //            }
 
-    //            const DX12GpuImageViewRef& ref = ObjCast<DX12GpuImageView>(valuesIt.second);
+    //            const DX12GpuImageViewRef& ref = DynamicCast<DX12GpuImageView>(valuesIt.second);
     //            if (!ref.IsValid() || !ref->IsCreated())
     //            {
     //                continue;
@@ -343,7 +343,7 @@ void DX12DescriptorSet::Update(bool force)
     //                continue;
     //            }
 
-    //            const DX12SamplerRef& ref = ObjCast<DX12Sampler>(valuesIt.second);
+    //            const DX12SamplerRef& ref = DynamicCast<DX12Sampler>(valuesIt.second);
     //            if (!ref.IsValid() || !ref->IsCreated())
     //            {
     //                continue;
@@ -379,7 +379,7 @@ void DX12DescriptorSet::Update(bool force)
     //                continue;
     //            }
 
-    //            const DX12GpuTlasRef& ref = ObjCast<DX12GpuTlas>(valuesIt.second);
+    //            const DX12GpuTlasRef& ref = DynamicCast<DX12GpuTlas>(valuesIt.second);
     //            if (!ref.IsValid() || !ref->IsCreated())
     //            {
     //                continue;

--- a/Source/Engine/rendering/dx12/DX12TextureViewCache.cpp
+++ b/Source/Engine/rendering/dx12/DX12TextureViewCache.cpp
@@ -18,15 +18,33 @@ namespace Hyperion {
 
 extern DX12RenderInterface* g_renderInterface;
 
+DX12TextureViewCache::DX12TextureViewCache()
+{
+    const size_t numSubtypes = GetNumDescendants(TypeId::ForType<Texture>()) + 1;
+    subtypeImpls.Resize(numSubtypes);
+}
+
 DX12TextureViewCache::~DX12TextureViewCache()
 {
-    for (auto& it : imageViews)
+    for (auto& subtype : subtypeImpls)
     {
-        for (auto& jt : it)
+        for (auto& it : subtype.imageViews)
         {
-            EnqueueDeletion(std::move(jt.second));
+            for (auto& jt : it)
+            {
+                EnqueueDeletion(std::move(jt.second));
+            }
         }
     }
+}
+
+DX12TextureViewCache::SubtypeData& DX12TextureViewCache::GetSubtypeData(ObjId<Texture> id)
+{
+    const int classIndex = GetSubclassIndex(TypeId::ForType<Texture>(), id.GetTypeId()) + 1;
+    AssertDebug(classIndex >= 0, "Invalid class index {}", classIndex);
+    AssertDebug(classIndex < int(subtypeImpls.Size()), "Invalid class index {}", classIndex);
+
+    return subtypeImpls[classIndex];
 }
 
 const DX12GpuImageViewRef& DX12TextureViewCache::GetOrCreate(
@@ -73,13 +91,15 @@ const DX12GpuImageViewRef& DX12TextureViewCache::GetOrCreate(
 
     const size_t idx = texture->Id().ToIndex();
 
-    if (!imageViews.HasIndex(idx))
+    SubtypeData& subtypeData = GetSubtypeData(texture->Id());
+
+    if (!subtypeData.imageViews.HasIndex(idx))
     {
-        imageViews.Emplace(idx);
-        weakTextureHandles.Emplace(idx, MakeWeakRef(texture));
+        subtypeData.imageViews.Emplace(idx);
+        subtypeData.weakTextureHandles.Emplace(idx, MakeWeakRef(texture));
     }
 
-    auto& textureImageViews = imageViews.Get(idx);
+    auto& textureImageViews = subtypeData.imageViews.Get(idx);
 
     auto it = textureImageViews.Find(subResource);
 
@@ -110,15 +130,17 @@ void DX12TextureViewCache::RemoveTexture(const Texture* texture)
 
     const size_t idx = texture->Id().ToIndex();
 
-    if (imageViews.HasIndex(idx))
+    SubtypeData& subtypeData = GetSubtypeData(texture->Id());
+
+    if (subtypeData.imageViews.HasIndex(idx))
     {
-        for (auto& it : imageViews.Get(idx))
+        for (auto& it : subtypeData.imageViews.Get(idx))
         {
             EnqueueDeletion(std::move(it.second));
         }
 
-        imageViews.EraseAt(idx);
-        weakTextureHandles.EraseAt(idx);
+        subtypeData.imageViews.EraseAt(idx);
+        subtypeData.weakTextureHandles.EraseAt(idx);
     }
 }
 
@@ -128,45 +150,41 @@ void DX12TextureViewCache::CleanupUnusedTextures()
 
     constexpr uint32 maxCycles = 32;
 
-    cleanupIterator = typename decltype(weakTextureHandles)::Iterator {
-        &weakTextureHandles,
-        cleanupIterator.page,
-        cleanupIterator.elem
-    };
-
-    if (cleanupIterator == weakTextureHandles.End())
-    {
-        cleanupIterator = weakTextureHandles.Begin();
-    }
-
     uint32 numRemoved = 0;
 
-    for (uint32 i = 0; cleanupIterator != weakTextureHandles.End() && i < maxCycles; i++)
+    for (auto& subtype : subtypeImpls)
     {
-        auto& entry = *cleanupIterator;
+        auto it = subtype.weakTextureHandles.Begin();
 
-        if (!entry.Lock())
+        for (uint32 i = 0; it != subtype.weakTextureHandles.End() && numRemoved < maxCycles; i++)
         {
-            const size_t idx = weakTextureHandles.IndexOf(cleanupIterator);
-
-            Assert(imageViews.HasIndex(idx));
-            Assert(weakTextureHandles.HasIndex(idx));
-
-            for (auto& it : imageViews.Get(idx))
+            if (!it->Lock())
             {
-                EnqueueDeletion(std::move(it.second));
+                const size_t idx = subtype.weakTextureHandles.IndexOf(it);
+
+                Assert(subtype.imageViews.HasIndex(idx));
+
+                for (auto& jt : subtype.imageViews.Get(idx))
+                {
+                    EnqueueDeletion(std::move(jt.second));
+                }
+
+                subtype.imageViews.EraseAt(idx);
+
+                it = subtype.weakTextureHandles.Erase(it);
+
+                ++numRemoved;
+
+                continue;
             }
 
-            imageViews.EraseAt(idx);
-
-            cleanupIterator = weakTextureHandles.Erase(cleanupIterator);
-
-            ++numRemoved;
-
-            continue;
+            ++it;
         }
 
-        ++cleanupIterator;
+        if (numRemoved >= maxCycles)
+        {
+            break;
+        }
     }
 
     if (numRemoved != 0)

--- a/Source/Engine/rendering/dx12/DX12TextureViewCache.hpp
+++ b/Source/Engine/rendering/dx12/DX12TextureViewCache.hpp
@@ -14,6 +14,7 @@
 #undef INCLUDE_FROM_RHI
 #undef INCLUDE_FROM_RHI_BASE
 
+#include <Core/containers/Array.hpp>
 #include <Core/containers/SparsePagedArray.hpp>
 #include <Core/containers/HashMap.hpp>
 
@@ -22,17 +23,15 @@ namespace Hyperion {
 class DX12TextureViewCache final : public TextureViewCacheBase
 {
 public:
-    // map texture ID -> image views
-    SparsePagedArray<HashMap<ImageSubResource, DX12GpuImageViewRef>, 1024> imageViews;
-    // to keep texture IDs as valid
-    SparsePagedArray<WeakHandle<Texture>, 1024> weakTextureHandles;
-
-    typename decltype(weakTextureHandles)::Iterator cleanupIterator;
-
-    DX12TextureViewCache()
+    struct SubtypeData
     {
-        cleanupIterator = weakTextureHandles.End();
-    }
+        SparsePagedArray<HashMap<ImageSubResource, DX12GpuImageViewRef>, 1024> imageViews;
+        SparsePagedArray<WeakHandle<Texture>, 1024> weakTextureHandles;
+    };
+
+    Array<SubtypeData, DynamicAllocator> subtypeImpls;
+
+    DX12TextureViewCache();
 
     ~DX12TextureViewCache() override;
 
@@ -54,6 +53,9 @@ public:
     
     void RemoveTexture(const Texture* texture) override;
     void CleanupUnusedTextures() override;
+
+private:
+    SubtypeData& GetSubtypeData(ObjId<Texture> id);
 };
 
 } // namespace Hyperion

--- a/Source/Engine/rendering/passes/BloomPass.cpp
+++ b/Source/Engine/rendering/passes/BloomPass.cpp
@@ -10,6 +10,7 @@
 #include <rendering/ShaderManager.hpp>
 #include <rendering/PlaceholderData.hpp>
 #include <rendering/GraphicsPipelineCache.hpp>
+#include <rendering/SamplerCache.hpp>
 #include <rendering/RenderInterface.hpp>
 #include <rendering/RenderObject.hpp>
 #include <rendering/Frame.hpp>
@@ -72,7 +73,8 @@ CVar<float> cvBloomIntensity { "Rendering.BloomIntensity", 1.0f, "Rendering.Bloo
 CVar<float> cvBloomSoftKnee { "Rendering.BloomSoftKnee", 0.5f, "Rendering.Bloom.SoftKnee" };
 
 BloomPass::BloomPass(Vec2u extent, GBuffer* gbuffer)
-    : FullScreenPass(TextureFormat::RGBA16F, extent, gbuffer)
+    : FullScreenPass(TextureFormat::RGBA16F, extent, gbuffer),
+      m_samplerClampToEdge(g_renderInterface->samplerCache->GetOrCreate(SamplerDesc { TFM_LINEAR, TFM_LINEAR, TWM_CLAMP_TO_EDGE }))
 {
 }
 
@@ -260,7 +262,7 @@ void BloomPass::ExtractBrightAreas(Frame* frame, const RenderSetup& renderSetup,
 
     cr << SetShaderUniform(numShaderUniforms++, "DeferredShadingTexture"_sh, dpd->deferredShadingFramebuffer->GetAttachment(0)->GetImageView());
 
-    cr << SetShaderUniform(numShaderUniforms++, "SamplerLinear"_sh, g_renderInterface->placeholderData->GetSamplerLinear());
+    cr << SetShaderUniform(numShaderUniforms++, "SamplerLinear"_sh, m_samplerClampToEdge);
     cr << SetShaderUniform(numShaderUniforms++, "SamplerNearest"_sh, g_renderInterface->placeholderData->GetSamplerNearest());
 
     cr << DispatchCompute(Vec3u { numGroups.x, numGroups.y, 1 });
@@ -300,7 +302,7 @@ void BloomPass::Downsample(Frame* frame, const RenderSetup& renderSetup)
         uint32 numShaderUniforms = 0;
 
         cr << SetShaderUniform(numShaderUniforms++, "InputTexture"_sh, g_renderInterface->textureViewCache->GetOrCreate(srcTexture));
-        cr << SetShaderUniform(numShaderUniforms++, "SamplerLinear"_sh, g_renderInterface->placeholderData->GetSamplerLinear());
+        cr << SetShaderUniform(numShaderUniforms++, "SamplerLinear"_sh, m_samplerClampToEdge);
         cr << SetShaderUniform(numShaderUniforms++, "SamplerNearest"_sh, g_renderInterface->placeholderData->GetSamplerNearest());
         cr << SetShaderUniform(numShaderUniforms++, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
 
@@ -356,7 +358,7 @@ void BloomPass::Upsample(Frame* frame, const RenderSetup& renderSetup)
 
         cr << SetShaderUniform(numShaderUniforms++, "PrevPassTexture"_sh, g_renderInterface->textureViewCache->GetOrCreate(prevTexture));
         cr << SetShaderUniform(numShaderUniforms++, "InputTexture"_sh, g_renderInterface->textureViewCache->GetOrCreate(blendTexture));
-        cr << SetShaderUniform(numShaderUniforms++, "SamplerLinear"_sh, g_renderInterface->placeholderData->GetSamplerLinear());
+        cr << SetShaderUniform(numShaderUniforms++, "SamplerLinear"_sh, m_samplerClampToEdge);
         cr << SetShaderUniform(numShaderUniforms++, "SamplerNearest"_sh, g_renderInterface->placeholderData->GetSamplerNearest());
         cr << SetShaderUniform(numShaderUniforms++, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
 

--- a/Source/Engine/rendering/passes/BloomPass.cpp
+++ b/Source/Engine/rendering/passes/BloomPass.cpp
@@ -76,28 +76,30 @@ BloomPass::BloomPass(Vec2u extent, GBuffer* gbuffer)
 {
 }
 
-BloomPass::~BloomPass()
-{
-    m_bloomResult.Reset();
+BloomPass::~BloomPass() = default;
 
-    EnqueueDeletion(FunctionWrapper<Proc<void()>>([
-        brightExtractTexture = m_brightExtractTexture,
-        downsamplePasses = std::move(m_downsamplePasses),
-        upsamplePasses = std::move(m_upsamplePasses)]() mutable -> void
-    {
-        brightExtractTexture.Reset();
-
-        for (size_t i = 0; i < downsamplePasses.Size(); i++)
-        {
-            downsamplePasses[i].Reset();
-        }
-
-        for (size_t i = 0; i < upsamplePasses.Size(); i++)
-        {
-            upsamplePasses[i].Reset();
-        }
-    }));
-}
+//BloomPass::~BloomPass()
+//{
+//    m_bloomResult.Reset();
+//
+//    EnqueueDeletion(FunctionWrapper<Proc<void()>>([
+//        brightExtractTexture = m_brightExtractTexture,
+//        downsamplePasses = std::move(m_downsamplePasses),
+//        upsamplePasses = std::move(m_upsamplePasses)]() mutable -> void
+//    {
+//        brightExtractTexture.Reset();
+//
+//        for (size_t i = 0; i < downsamplePasses.Size(); i++)
+//        {
+//            downsamplePasses[i].Reset();
+//        }
+//
+//        for (size_t i = 0; i < upsamplePasses.Size(); i++)
+//        {
+//            upsamplePasses[i].Reset();
+//        }
+//    }));
+//}
 
 void BloomPass::Resize_Internal(Vec2u newSize)
 {

--- a/Source/Engine/rendering/passes/BloomPass.cpp
+++ b/Source/Engine/rendering/passes/BloomPass.cpp
@@ -1,0 +1,376 @@
+/*!
+ *  @author: The Hyperion Contributors
+ *  @date 2016-2026
+ *  @licence MIT
+ */
+
+#include <RenderingPch.hpp>
+
+#include <rendering/passes/BloomPass.hpp>
+#include <rendering/ShaderManager.hpp>
+#include <rendering/PlaceholderData.hpp>
+#include <rendering/GraphicsPipelineCache.hpp>
+#include <rendering/RenderInterface.hpp>
+#include <rendering/RenderObject.hpp>
+#include <rendering/Frame.hpp>
+#include <rendering/RenderProxy.hpp>
+#include <rendering/GraphicsPipeline.hpp>
+#include <rendering/DescriptorSet.hpp>
+#include <rendering/Mesh.hpp>
+#include <rendering/GBuffer.hpp>
+#include <rendering/TextureViewCache.hpp>
+#include <rendering/Texture.hpp>
+
+#include <rendering/renderers/DeferredRenderer.hpp>
+
+#include <rendering/util/DeletionQueue.hpp>
+
+#include <rendering/CBufferAllocator.hpp>
+
+#include <scene/View.hpp>
+
+#include <system/AppContext.hpp>
+
+#include <Core/math/Vector2.hpp>
+
+#include <engine/EngineDriver.hpp>
+#include <engine/CVarManager.hpp>
+
+#include <asset/AssetRegistry.hpp>
+
+namespace Hyperion {
+
+class DeferredRendererPassData;
+
+HYP_DECLARE_LOG_CHANNEL(Rendering);
+
+struct BloomUniforms
+{
+    Vec2u dimension;
+    float threshold;
+    float intensity;
+    float softKnee;
+};
+
+struct DownsampleUniforms
+{
+    Vec2u srcDimension;
+    Vec2u dstDimension;
+    Vec2f invDimension;
+    Vec2f padding;
+};
+
+struct UpsampleUniforms
+{
+    Vec2f texelSize;
+    float scatter; // blend factor: 0=only coarse mips, 1=only fine mips (0.5 is a good default)
+    float padding;
+};
+
+CVar<float> cvBloomThreshold { "Rendering.BloomThreshold", 1.0f, "Rendering.Bloom.Threshold" };
+CVar<float> cvBloomIntensity { "Rendering.BloomIntensity", 1.0f, "Rendering.Bloom.Intensity" };
+CVar<float> cvBloomSoftKnee { "Rendering.BloomSoftKnee", 0.5f, "Rendering.Bloom.SoftKnee" };
+
+BloomPass::BloomPass(Vec2u extent, GBuffer* gbuffer)
+    : FullScreenPass(TextureFormat::RGBA16F, extent, gbuffer)
+{
+}
+
+BloomPass::~BloomPass()
+{
+    m_bloomResult.Reset();
+
+    EnqueueDeletion(FunctionWrapper<Proc<void()>>([
+        brightExtractTexture = m_brightExtractTexture,
+        downsamplePasses = std::move(m_downsamplePasses),
+        upsamplePasses = std::move(m_upsamplePasses)]() mutable -> void
+    {
+        brightExtractTexture.Reset();
+
+        for (size_t i = 0; i < downsamplePasses.Size(); i++)
+        {
+            downsamplePasses[i].Reset();
+        }
+
+        for (size_t i = 0; i < upsamplePasses.Size(); i++)
+        {
+            upsamplePasses[i].Reset();
+        }
+    }));
+}
+
+void BloomPass::Resize_Internal(Vec2u newSize)
+{
+    HYP_SCOPE;
+    AssertOnThread(g_renderThread);
+
+    // Updates m_extent and recreates the base framebuffer.
+    FullScreenPass::Resize_Internal(newSize);
+
+    const Vec2u extent = ShouldRenderHalfRes() ? m_extent / 2 : m_extent;
+
+    // Recreate the bright-extract texture at the new resolution.
+    m_brightExtractTexture = MakeHandle<Texture>(TextureDesc {
+        TextureType::Texture2D,
+        TextureFormat::RGBA16F,
+        Vec3u(extent, 1),
+        TFM_LINEAR,
+        TFM_LINEAR,
+        TWM_CLAMP_TO_EDGE,
+        1,
+        IU_STORAGE | IU_SAMPLED
+    });
+    m_brightExtractTexture->SetIsTransient(true);
+    m_brightExtractTexture->SetName(NAME("BloomBrightExtract"));
+    CheckResult(m_brightExtractTexture->Create());
+    GetEngineAssetRegistry()->PutAsset(m_brightExtractTexture);
+
+    for (uint32 i = 0; i < NumMipLevels - 1; i++)
+    {
+        const Vec2u targetExtent = MathUtil::Max(Vec2u(extent.x >> (i + 1), extent.y >> (i + 1)), Vec2u::One());
+        m_downsamplePasses[i]->Resize(targetExtent);
+    }
+
+    for (uint32 i = 0; i < NumMipLevels - 1; i++)
+    {
+        const Vec2u targetExtent = MathUtil::Max(Vec2u(extent.x >> (NumMipLevels - 2 - i), extent.y >> (NumMipLevels - 2 - i)), Vec2u::One());
+        m_upsamplePasses[i]->Resize(targetExtent);
+    }
+
+    m_bloomResult = MakeStrongRef(m_upsamplePasses[NumMipLevels - 2]->GetAttachment(0));
+}
+
+void BloomPass::Create()
+{
+    Assert(m_gbuffer != nullptr);
+
+    FullScreenPass::Create();
+
+    Vec2u extent = ShouldRenderHalfRes() ? m_extent / 2 : m_extent;
+
+    m_brightExtractTexture = MakeHandle<Texture>(TextureDesc {
+        TextureType::Texture2D,
+        TextureFormat::RGBA16F,
+        Vec3u(extent, 1),
+        TFM_LINEAR,
+        TFM_LINEAR,
+        TWM_CLAMP_TO_EDGE,
+        1,
+        IU_STORAGE | IU_SAMPLED
+    });
+    m_brightExtractTexture->SetIsTransient(true);
+    m_brightExtractTexture->SetName(NAME("BloomBrightExtract"));
+    CheckResult(m_brightExtractTexture->Create());
+
+    GetEngineAssetRegistry()->PutAsset(m_brightExtractTexture);
+
+    for (uint32 i = 0; i < NumMipLevels - 1; i++)
+    {
+        // Each downsample step halves resolution: ds[0]=1/2, ds[1]=1/4, ds[2]=1/8 ...
+        Vec2u targetExtent = MathUtil::Max(Vec2u(extent.x >> (i + 1), extent.y >> (i + 1)), Vec2u::One());
+
+        m_downsamplePasses[i] = MakeUnique<FullScreenPass>(
+            TextureFormat::RGBA16F,
+            targetExtent,
+            nullptr,
+            FSP_NONE);
+
+        m_downsamplePasses[i]->SetShaderDesc(ShaderDesc(NAME("BloomDownsample"), GetShaderProperties()));
+        m_downsamplePasses[i]->Create();
+    }
+
+    for (uint32 i = 0; i < NumMipLevels - 1; i++)
+    {
+        Vec2u targetExtent = MathUtil::Max(Vec2u(extent.x >> (NumMipLevels - 2 - i), extent.y >> (NumMipLevels - 2 - i)), Vec2u::One());
+
+        m_upsamplePasses[i] = MakeUnique<FullScreenPass>(
+            TextureFormat::RGBA16F,
+            targetExtent,
+            nullptr,
+            FSP_NONE);
+
+        m_upsamplePasses[i]->SetShaderDesc(ShaderDesc(NAME("BloomUpsample"), GetShaderProperties()));
+        m_upsamplePasses[i]->Create();
+    }
+}
+
+void BloomPass::Render(Frame* frame, const RenderSetup& renderSetup)
+{
+    HYP_SCOPE;
+    AssertOnThread(g_renderThread);
+
+    AssertDebug(renderSetup.world && renderSetup.view);
+    AssertDebug(renderSetup.passData != nullptr);
+
+    const uint32 frameIndex = frame->GetFrameIndex();
+
+    DeferredRendererPassData* dpd = DynamicCast<DeferredRendererPassData>(renderSetup.passData);
+    AssertDebug(dpd != nullptr);
+
+    const FramebufferRef& inputsFramebuffer = dpd->view.GetUnsafe()->GetOutputTarget().GetFramebuffer(RenderBucket::Opaque);
+
+    CommandRecorder& cr = frame->cr;
+
+    ExtractBrightAreas(frame, renderSetup, inputsFramebuffer, dpd);
+    Downsample(frame, renderSetup);
+    Upsample(frame, renderSetup);
+}
+
+ShaderPropertySet BloomPass::GetShaderProperties() const
+{
+    ShaderPropertySet shaderProperties;
+    return shaderProperties;
+}
+
+void BloomPass::ExtractBrightAreas(Frame* frame, const RenderSetup& renderSetup, const FramebufferRef& inputsFramebuffer, DeferredRendererPassData* dpd)
+{
+    HYP_SCOPE;
+
+    CommandRecorder& cr = frame->cr;
+
+    const Vec2u extent = ShouldRenderHalfRes() ? m_extent / 2 : m_extent;
+
+    const Vec2u numGroups(
+        (extent.x + 15) / 16,
+        (extent.y + 15) / 16);
+
+    GpuBuffer* cbuffer = nullptr;
+    size_t cbufferOffset = 0;
+    size_t cbufferSize = 0;
+
+    BloomUniforms bloomConstants {};
+    bloomConstants.dimension = extent;
+    bloomConstants.threshold = cvBloomThreshold.Get();
+    bloomConstants.intensity = cvBloomIntensity.Get();
+    bloomConstants.softKnee = cvBloomSoftKnee.Get();
+
+    g_renderInterface->cbufferAllocator->Write(&bloomConstants);
+    g_renderInterface->cbufferAllocator->Commit(cbuffer, cbufferOffset, cbufferSize);
+
+    cr << InsertBarrier(m_brightExtractTexture->GetGpuImage(), RS_UNORDERED_ACCESS);
+
+    cr << SetCurrentShader(ShaderDesc(NAME("BloomExtract"), GetShaderProperties()));
+
+    uint32 numShaderUniforms = 0;
+
+    cr << SetShaderUniform(numShaderUniforms++, "OutImage"_sh, g_renderInterface->textureViewCache->GetOrCreate(m_brightExtractTexture));
+    cr << SetShaderUniform(numShaderUniforms++, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
+
+    cr << SetShaderUniform(numShaderUniforms++, "DeferredShadingTexture"_sh, dpd->deferredShadingFramebuffer->GetAttachment(0)->GetImageView());
+
+    cr << SetShaderUniform(numShaderUniforms++, "SamplerLinear"_sh, g_renderInterface->placeholderData->GetSamplerLinear());
+    cr << SetShaderUniform(numShaderUniforms++, "SamplerNearest"_sh, g_renderInterface->placeholderData->GetSamplerNearest());
+
+    cr << DispatchCompute(Vec3u { numGroups.x, numGroups.y, 1 });
+
+    cr << InsertBarrier(m_brightExtractTexture->GetGpuImage(), RS_SHADER_RESOURCE);
+}
+
+void BloomPass::Downsample(Frame* frame, const RenderSetup& renderSetup)
+{
+    HYP_SCOPE;
+
+    CommandRecorder& cr = frame->cr;
+
+    for (uint32 i = 0; i < NumMipLevels - 1; i++)
+    {
+        FullScreenPass* pass = m_downsamplePasses[i].Get();
+
+        Texture* srcTexture = (i == 0) ? m_brightExtractTexture.Get() : m_downsamplePasses[i - 1]->GetAttachment(0);
+
+        const Vec2u srcExtent = (i == 0) ? m_extent : m_downsamplePasses[i - 1]->GetExtent();
+        const Vec2u dstExtent = pass->GetExtent();
+
+        GpuBuffer* cbuffer = nullptr;
+        size_t cbufferOffset = 0;
+        size_t cbufferSize = 0;
+
+        DownsampleUniforms constants {};
+        constants.srcDimension = srcExtent;
+        constants.dstDimension = dstExtent;
+        constants.invDimension = Vec2f(1.0f) / Vec2f(dstExtent);
+
+        g_renderInterface->cbufferAllocator->Write(&constants);
+        g_renderInterface->cbufferAllocator->Commit(cbuffer, cbufferOffset, cbufferSize);
+
+        pass->Begin(frame, renderSetup);
+
+        uint32 numShaderUniforms = 0;
+
+        cr << SetShaderUniform(numShaderUniforms++, "InputTexture"_sh, g_renderInterface->textureViewCache->GetOrCreate(srcTexture));
+        cr << SetShaderUniform(numShaderUniforms++, "SamplerLinear"_sh, g_renderInterface->placeholderData->GetSamplerLinear());
+        cr << SetShaderUniform(numShaderUniforms++, "SamplerNearest"_sh, g_renderInterface->placeholderData->GetSamplerNearest());
+        cr << SetShaderUniform(numShaderUniforms++, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
+
+        pass->RenderFullScreenQuad(frame, renderSetup);
+
+        pass->End(frame, renderSetup);
+
+        cr << InsertBarrier(pass->GetAttachment(0)->GetGpuImage(), RS_SHADER_RESOURCE);
+    }
+}
+
+void BloomPass::Upsample(Frame* frame, const RenderSetup& renderSetup)
+{
+    HYP_SCOPE;
+
+    CommandRecorder& cr = frame->cr;
+
+    for (uint32 i = 0; i < NumMipLevels - 1; i++)
+    {
+        FullScreenPass* pass = m_upsamplePasses[i].Get();
+
+        Texture* prevTexture = (i == 0)
+            ? m_downsamplePasses[NumMipLevels - 2]->GetAttachment(0)
+            : m_upsamplePasses[i - 1]->GetAttachment(0);
+
+        Texture* blendTexture;
+        if (i == NumMipLevels - 2)
+        {
+            blendTexture = m_brightExtractTexture.Get();
+        }
+        else
+        {
+            const uint32 dsBlendIndex = (NumMipLevels - 3) - i;
+            blendTexture = m_downsamplePasses[dsBlendIndex]->GetAttachment(0);
+        }
+
+        const Vec2u targetExtent = m_upsamplePasses[i]->GetExtent();
+
+        GpuBuffer* cbuffer = nullptr;
+        size_t cbufferOffset = 0;
+        size_t cbufferSize = 0;
+
+        UpsampleUniforms constants {};
+        constants.texelSize = Vec2f(1.0f) / Vec2f(targetExtent);
+        constants.scatter = 0.5f;
+
+        g_renderInterface->cbufferAllocator->Write(&constants);
+        g_renderInterface->cbufferAllocator->Commit(cbuffer, cbufferOffset, cbufferSize);
+
+        pass->Begin(frame, renderSetup);
+
+        uint32 numShaderUniforms = 0;
+
+        cr << SetShaderUniform(numShaderUniforms++, "PrevPassTexture"_sh, g_renderInterface->textureViewCache->GetOrCreate(prevTexture));
+        cr << SetShaderUniform(numShaderUniforms++, "InputTexture"_sh, g_renderInterface->textureViewCache->GetOrCreate(blendTexture));
+        cr << SetShaderUniform(numShaderUniforms++, "SamplerLinear"_sh, g_renderInterface->placeholderData->GetSamplerLinear());
+        cr << SetShaderUniform(numShaderUniforms++, "SamplerNearest"_sh, g_renderInterface->placeholderData->GetSamplerNearest());
+        cr << SetShaderUniform(numShaderUniforms++, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
+
+        pass->RenderFullScreenQuad(frame, renderSetup);
+
+        pass->End(frame, renderSetup);
+
+        cr << InsertBarrier(pass->GetAttachment(0)->GetGpuImage(), RS_SHADER_RESOURCE);
+    }
+
+    m_bloomResult = MakeStrongRef(m_upsamplePasses[NumMipLevels - 2]->GetAttachment(0));
+}
+
+const Handle<Texture>& BloomPass::GetBloomResult() const
+{
+    return m_bloomResult;
+}
+
+} // namespace Hyperion

--- a/Source/Engine/rendering/passes/BloomPass.hpp
+++ b/Source/Engine/rendering/passes/BloomPass.hpp
@@ -11,6 +11,8 @@
 
 #include <Core/reflection/Handle.hpp>
 
+#include <rendering/Sampler.hpp>
+
 namespace Hyperion {
 
 class Texture;
@@ -57,6 +59,7 @@ private:
     FixedArray<UniquePtr<FullScreenPass>, NumMipLevels - 1>  m_upsamplePasses;
 
     Handle<Texture> m_bloomResult;
+    Sampler* m_samplerClampToEdge;
 };
 
 } // namespace Hyperion

--- a/Source/Engine/rendering/passes/BloomPass.hpp
+++ b/Source/Engine/rendering/passes/BloomPass.hpp
@@ -1,0 +1,62 @@
+/*!
+ *  @author: The Hyperion Contributors
+ *  @date 2016-2026
+ *  @licence MIT
+ */
+
+#pragma once
+
+#include <rendering/FullScreenPass.hpp>
+#include <rendering/RenderObject.hpp>
+
+#include <Core/reflection/Handle.hpp>
+
+namespace Hyperion {
+
+class Texture;
+class GBuffer;
+
+class BloomPass final : public FullScreenPass
+{
+public:
+    BloomPass(Vec2u extent, GBuffer* gbuffer);
+    BloomPass(const BloomPass& other) = delete;
+    BloomPass& operator=(const BloomPass& other) = delete;
+    ~BloomPass() override;
+
+    const Handle<Texture>& GetBloomResult() const;
+
+    void Create() override;
+    
+    void Render(Frame* frame, const RenderSetup& renderSetup) override;
+
+protected:
+    bool UsesTemporalBlending() const override
+    {
+        return false;
+    }
+
+    bool ShouldRenderHalfRes() const override
+    {
+        return false;
+    }
+
+    void Resize_Internal(Vec2u newSize) override;
+
+    ShaderPropertySet GetShaderProperties() const;
+
+private:
+    void ExtractBrightAreas(Frame* frame, const RenderSetup& renderSetup, const FramebufferRef& inputsFramebuffer, class DeferredRendererPassData* dpd);
+    void Downsample(Frame* frame, const RenderSetup& renderSetup);
+    void Upsample(Frame* frame, const RenderSetup& renderSetup);
+
+    static constexpr uint32 NumMipLevels = 6;
+
+    Handle<Texture> m_brightExtractTexture;
+    FixedArray<UniquePtr<FullScreenPass>, NumMipLevels - 1> m_downsamplePasses;
+    FixedArray<UniquePtr<FullScreenPass>, NumMipLevels - 1>  m_upsamplePasses;
+
+    Handle<Texture> m_bloomResult;
+};
+
+} // namespace Hyperion

--- a/Source/Engine/rendering/passes/HBAOPass.cpp
+++ b/Source/Engine/rendering/passes/HBAOPass.cpp
@@ -97,14 +97,6 @@ void HBAO::Render(Frame* frame, const RenderSetup& renderSetup)
         m_cbuffer->Flush(0, sizeof(constants));
     }
 
-    Begin(frame, renderSetup);
-
-    DeferredRendererPassData* dpd = DynamicCast<DeferredRendererPassData>(renderSetup.passData);
-    AssertDebug(dpd != nullptr);
-
-    const FramebufferRef& inputsFramebuffer = dpd->view.GetUnsafe()->GetOutputTarget().GetFramebuffer(RenderBucket::Opaque);
-    AssertDebug(inputsFramebuffer.IsValid());
-
     ShaderPropertySet shaderProperties;
 
     if (ShouldRenderHalfRes())
@@ -112,7 +104,15 @@ void HBAO::Render(Frame* frame, const RenderSetup& renderSetup)
         shaderProperties.Add(s_propHalfRes);
     }
 
-    cr << SetCurrentShader(ShaderDesc(NAME("HBAO"), shaderProperties));
+    m_shaderDesc = ShaderDesc(NAME("HBAO"), shaderProperties);
+
+    Begin(frame, renderSetup);
+
+    DeferredRendererPassData* dpd = DynamicCast<DeferredRendererPassData>(renderSetup.passData);
+    AssertDebug(dpd != nullptr);
+
+    const FramebufferRef& inputsFramebuffer = dpd->view.GetUnsafe()->GetOutputTarget().GetFramebuffer(RenderBucket::Opaque);
+    AssertDebug(inputsFramebuffer.IsValid());
 
     uint32 numShaderUniforms = 0;
 

--- a/Source/Engine/rendering/passes/HBAOPass.cpp
+++ b/Source/Engine/rendering/passes/HBAOPass.cpp
@@ -8,7 +8,6 @@
 
 #include <rendering/passes/HBAOPass.hpp>
 #include <rendering/ShaderManager.hpp>
-#include <rendering/RenderGroup.hpp>
 #include <rendering/PlaceholderData.hpp>
 #include <rendering/GraphicsPipelineCache.hpp>
 #include <rendering/RenderInterface.hpp>
@@ -100,7 +99,7 @@ void HBAO::Render(Frame* frame, const RenderSetup& renderSetup)
 
     Begin(frame, renderSetup);
 
-    DeferredRendererPassData* dpd = ObjCast<DeferredRendererPassData>(renderSetup.passData);
+    DeferredRendererPassData* dpd = DynamicCast<DeferredRendererPassData>(renderSetup.passData);
     AssertDebug(dpd != nullptr);
 
     const FramebufferRef& inputsFramebuffer = dpd->view.GetUnsafe()->GetOutputTarget().GetFramebuffer(RenderBucket::Opaque);

--- a/Source/Engine/rendering/renderers/DeferredRenderer.cpp
+++ b/Source/Engine/rendering/renderers/DeferredRenderer.cpp
@@ -390,7 +390,7 @@ void DeferredPass::RenderToFramebuffer_Internal(Frame* frame, const RenderSetup&
 
     const Vec4f& cameraPosition = cameraProxy->bufferData.cameraPosition;
 
-    DeferredRendererPassData* dpd = ObjCast<DeferredRendererPassData>(rs.passData);
+    DeferredRendererPassData* dpd = DynamicCast<DeferredRendererPassData>(rs.passData);
     AssertDebug(dpd != nullptr);
 
     Framebuffer* opaquePassFramebuffer = dpd->view.GetUnsafe()->GetOutputTarget().GetFramebuffer(RenderBucket::Opaque);
@@ -787,7 +787,7 @@ void TonemapPass::Render(Frame* frame, const RenderSetup& rs)
 
     CommandRecorder& cr = frame->cr;
 
-    DeferredRendererPassData* dpd = ObjCast<DeferredRendererPassData>(rs.passData);
+    DeferredRendererPassData* dpd = DynamicCast<DeferredRendererPassData>(rs.passData);
     AssertDebug(dpd != nullptr);
 
     const uint32 frameIndex = frame->GetFrameIndex();
@@ -899,7 +899,7 @@ void LightmapPass::RenderToFramebuffer_Internal(Frame* frame, const RenderSetup&
 
     const uint32 frameIndex = frame->GetFrameIndex();
 
-    LightmapVolume* volume = ObjCast<LightmapVolume>(renderSetup.volume);
+    LightmapVolume* volume = DynamicCast<LightmapVolume>(renderSetup.volume);
     AssertDebug(volume != nullptr);
 
     RenderProxyLightmapVolume* proxy = static_cast<RenderProxyLightmapVolume*>(GetRenderProxy(volume));
@@ -910,7 +910,7 @@ void LightmapPass::RenderToFramebuffer_Internal(Frame* frame, const RenderSetup&
         return; // nothing to do
     }
 
-    DeferredRendererPassData* dpd = ObjCast<DeferredRendererPassData>(renderSetup.passData);
+    DeferredRendererPassData* dpd = DynamicCast<DeferredRendererPassData>(renderSetup.passData);
     AssertDebug(dpd != nullptr);
 
     Framebuffer* viewFramebuffer = dpd->view.GetUnsafe()->GetOutputTarget().GetFramebuffer(RenderBucket::Opaque);
@@ -1074,10 +1074,10 @@ void FogVolumePass::RenderToFramebuffer_Internal(Frame* frame, const RenderSetup
 
     AssertDebug(renderSetup.world && renderSetup.volume && renderSetup.view);
 
-    DeferredRendererPassData* dpd = ObjCast<DeferredRendererPassData>(renderSetup.passData);
+    DeferredRendererPassData* dpd = DynamicCast<DeferredRendererPassData>(renderSetup.passData);
     AssertDebug(dpd != nullptr);
 
-    FogVolume* volume = ObjCast<FogVolume>(renderSetup.volume);
+    FogVolume* volume = DynamicCast<FogVolume>(renderSetup.volume);
     AssertDebug(volume != nullptr);
 
     RenderProxyFogVolume* proxy = static_cast<RenderProxyFogVolume*>(GetRenderProxy(volume));
@@ -1362,7 +1362,7 @@ void ReflectionsPass::Render(Frame* frame, const RenderSetup& rs)
     cr << SetShaderUniform(0, "SamplerLinear"_sh, g_renderInterface->placeholderData->GetSamplerLinearMipmap());
     cr << SetShaderUniform(1, "SamplerNearest"_sh, g_renderInterface->placeholderData->GetSamplerNearest());
 
-    DeferredRendererPassData* dpd = ObjCast<DeferredRendererPassData>(rs.passData);
+    DeferredRendererPassData* dpd = DynamicCast<DeferredRendererPassData>(rs.passData);
     AssertDebug(dpd != nullptr);
 
     const FramebufferRef& opaquePassFramebuffer = dpd->view.GetUnsafe()->GetOutputTarget().GetFramebuffer(RenderBucket::Opaque);
@@ -2285,7 +2285,7 @@ void DeferredRenderer::RenderFrame(Frame* frame, const RenderSetup& rs)
                 PassData* pd = FetchViewPassData(view);
                 Assert(pd != nullptr);
 
-                DeferredRendererPassData* pdCasted = ObjCast<DeferredRendererPassData>(pd);
+                DeferredRendererPassData* pdCasted = DynamicCast<DeferredRendererPassData>(pd);
                 Assert(pdCasted != nullptr);
 
                 pdCasted->priority = view->GetPriority();
@@ -2301,7 +2301,7 @@ void DeferredRenderer::RenderFrame(Frame* frame, const RenderSetup& rs)
             PassData* pd = FetchViewPassData(view);
             Assert(pd != nullptr);
 
-            RayTracingPassData* pdCasted = ObjCast<RayTracingPassData>(pd);
+            RayTracingPassData* pdCasted = DynamicCast<RayTracingPassData>(pd);
             Assert(pdCasted != nullptr);
 
             RenderSetup newRenderSetup = rs.Fork();
@@ -2434,7 +2434,7 @@ void DeferredRenderer::RenderFrame(Frame* frame, const RenderSetup& rs)
             continue;
         }
 
-        DeferredRendererPassData* pd = ObjCast<DeferredRendererPassData>(FetchViewPassData(view));
+        DeferredRendererPassData* pd = DynamicCast<DeferredRendererPassData>(FetchViewPassData(view));
         AssertDebug(pd != nullptr);
 
         RenderSetup currentViewSetup = rs.Fork();
@@ -2494,7 +2494,7 @@ void DeferredRenderer::RenderFrameForView(Frame* frame, const RenderSetup& rs)
     renderCollector.BeginRecordDrawCalls(frame, rs, RenderBucketMask<
         RenderBucket::Opaque, RenderBucket::Translucent, RenderBucket::Lightmapped, RenderBucket::Sky>);
 
-    DeferredRendererPassData* passDataCasted = ObjCast<DeferredRendererPassData>(rs.passData);
+    DeferredRendererPassData* passDataCasted = DynamicCast<DeferredRendererPassData>(rs.passData);
     AssertDebug(passDataCasted != nullptr);
 
     DeferredRendererPassData& passData = *passDataCasted;
@@ -2643,7 +2643,7 @@ void DeferredRenderer::RenderFrameForView(Frame* frame, const RenderSetup& rs)
 
         if (rayTracingView != nullptr)
         {
-            RayTracingPassData* rayTracingPassData = ObjCast<RayTracingPassData>(FetchViewPassData(rayTracingView));
+            RayTracingPassData* rayTracingPassData = DynamicCast<RayTracingPassData>(FetchViewPassData(rayTracingView));
             Assert(rayTracingPassData != nullptr);
 
             const GpuTlasRef& tlas = rayTracingPassData->rayTracingTlases[frameIndex];
@@ -2887,7 +2887,7 @@ void DeferredRenderer::UpdateRayTracingView(Frame* frame, const RenderSetup& rs)
 
     const uint32 currentFrameIndex = frame->GetFrameIndex();
 
-    RayTracingPassData* pd = ObjCast<RayTracingPassData>(rs.passData);
+    RayTracingPassData* pd = DynamicCast<RayTracingPassData>(rs.passData);
 
     RenderProxyList& rpl = GetConsumerProxyList(rs.view);
     rpl.BeginRead();
@@ -3014,7 +3014,7 @@ void DeferredRenderer::GenerateMipChain(Frame* frame, const RenderSetup& rs, Ren
 
     const uint32 frameIndex = frame->GetFrameIndex();
 
-    DeferredRendererPassData* pd = ObjCast<DeferredRendererPassData>(rs.passData);
+    DeferredRendererPassData* pd = DynamicCast<DeferredRendererPassData>(rs.passData);
 
     const GpuImageRef& mipmappedResult = pd->mipChain->GetGpuImage();
     Assert(mipmappedResult.IsValid());

--- a/Source/Engine/rendering/renderers/DeferredRenderer.cpp
+++ b/Source/Engine/rendering/renderers/DeferredRenderer.cpp
@@ -9,6 +9,7 @@
 #include <rendering/renderers/DeferredRenderer.hpp>
 #include <rendering/renderers/EnvProbeRenderer.hpp>
 #include <rendering/renderers/UIRenderer.hpp>
+#include <rendering/renderers/SpriteRenderer.hpp>
 
 #include <rendering/RenderGroup.hpp>
 #include <rendering/MaterialTextureCache.hpp>
@@ -2844,6 +2845,15 @@ void DeferredRenderer::RenderFrameForView(Frame* frame, const RenderSetup& rs)
                 particleVolumeRS.volume = particleVolume;
 
                 g_renderInterface->globalRenderers[GRT_PARTICLE_VOLUME][0]->RenderFrame(frame, particleVolumeRS);
+            }
+        }
+
+        { // draw sprites
+            SpriteRenderer* spriteRenderer = static_cast<SpriteRenderer*>(g_renderInterface->globalRenderers[GRT_SPRITE][0]);
+
+            if (spriteRenderer != nullptr)
+            {
+                spriteRenderer->RenderFrame(frame, rs);
             }
         }
 

--- a/Source/Engine/rendering/renderers/DeferredRenderer.cpp
+++ b/Source/Engine/rendering/renderers/DeferredRenderer.cpp
@@ -20,6 +20,7 @@
 #include <rendering/passes/SSRPass.hpp>
 #include <rendering/SSGI.hpp>
 #include <rendering/passes/HBAOPass.hpp>
+#include <rendering/passes/BloomPass.hpp>
 #include <rendering/DepthOfField.hpp>
 #include <rendering/Mesh.hpp>
 #include <rendering/MaterialInstance.hpp>
@@ -165,6 +166,7 @@ CVar<bool> cvSSGI { "Rendering.SSGI", true };
 CVar<bool> cvSSR { "Rendering.SSR", true, "Rendering.SSR.Enabled" };
 CVar<bool> cvTAA { "Rendering.TAA", true };
 CVar<bool> cvHBAO { "Rendering.HBAO", true, "Rendering.HBAO.Enabled" };
+CVar<bool> cvBloom { "Rendering.Bloom", true, "Rendering.Bloom.Enabled" };
 CVar<bool> cvEnableLightmapVolumes { "Rendering.LightmapVolumes", true };
 CVar<bool> cvClusteredShading { "Rendering.ClusteredShading", true };
 CVar<float> cvTonemapExposure { "Rendering.Tonemap.Exposure", 1.8f };
@@ -812,6 +814,15 @@ void TonemapPass::Render(Frame* frame, const RenderSetup& rs)
 
     cr << SetShaderUniform(numShaderUniforms++, "SamplerNearest"_sh, g_renderInterface->placeholderData->GetSamplerNearest());
     cr << SetShaderUniform(numShaderUniforms++, "SamplerLinear"_sh, g_renderInterface->placeholderData->GetSamplerLinear());
+
+    if (cvBloom.Get() && dpd->bloomPass)
+    {
+        cr << SetShaderUniform(numShaderUniforms++, "BloomResultTexture"_sh, g_renderInterface->textureViewCache->GetOrCreate(dpd->bloomPass->GetBloomResult()));
+    }
+    else
+    {
+        cr << SetShaderUniform(numShaderUniforms++, "BloomResultTexture"_sh, g_renderInterface->placeholderData->GetImageView2D1x1R8());
+    }
 
     if (dpd->rayTracingReflections)
     {
@@ -2040,6 +2051,9 @@ PassData* DeferredRenderer::CreateViewPassData(View* view, PassDataExt&)
         passData.ssgi = MakeUnique<SSGI>(gbuffer);
         passData.ssgi->Create();
 
+        passData.bloomPass = MakeUnique<BloomPass>(gbuffer->GetExtent(), gbuffer);
+        passData.bloomPass->Create();
+
         passData.postProcessing = MakeUnique<PostProcessing>();
         passData.postProcessing->Create();
 
@@ -2204,6 +2218,10 @@ void DeferredRenderer::ResizeView(Viewport viewport, View* view, DeferredRendere
     passData.ssgi.Reset();
     passData.ssgi = MakeUnique<SSGI>(gbuffer);
     passData.ssgi->Create();
+
+    passData.bloomPass.Reset();
+    passData.bloomPass = MakeUnique<BloomPass>(viewport.extent, gbuffer);
+    passData.bloomPass->Create();
 
     passData.reflectionsPass.Reset();
     passData.reflectionsPass = MakeUnique<ReflectionsPass>(
@@ -2709,7 +2727,6 @@ void DeferredRenderer::RenderFrameForView(Frame* frame, const RenderSetup& rs)
 
         if (Texture* ssrResultTexture = passData.reflectionsPass->ssrPass->GetFinalResultTexture())
         {
-            // make sure it is in a state for reading, we don't want any transitions between lightmap -> deferred indirect pass.
             frame->cr << InsertBarrier(
                 ssrResultTexture->GetGpuImage(),
                 RS_SHADER_RESOURCE,
@@ -2829,6 +2846,11 @@ void DeferredRenderer::RenderFrameForView(Frame* frame, const RenderSetup& rs)
         }
 
         frame->cr << SetCurrentFramebuffer(nullptr);
+    }
+
+    if (cvBloom.Get())
+    {
+        passData.bloomPass->Render(frame, rs);
     }
 
     // debug draw

--- a/Source/Engine/rendering/renderers/DeferredRenderer.cpp
+++ b/Source/Engine/rendering/renderers/DeferredRenderer.cpp
@@ -1490,6 +1490,8 @@ DeferredRendererPassData::~DeferredRendererPassData()
 
     ssgi.Reset();
 
+    bloomPass.Reset();
+
     postProcessing->Destroy();
     postProcessing.Reset();
 

--- a/Source/Engine/rendering/renderers/DeferredRenderer.hpp
+++ b/Source/Engine/rendering/renderers/DeferredRenderer.hpp
@@ -36,6 +36,7 @@ class FullScreenPass;
 class TAAPass;
 class PostProcessing;
 class HBAO;
+class BloomPass;
 class SSAO;
 class DOFBlur;
 class Texture;
@@ -301,6 +302,7 @@ public:
     UniquePtr<PostProcessing> postProcessing;
     UniquePtr<TAAPass> taaPass;
     UniquePtr<SSGI> ssgi;
+    UniquePtr<BloomPass> bloomPass;
     UniquePtr<DepthPyramidRenderer> depthPyramidRenderer;
     UniquePtr<DOFBlur> dofBlur;
 

--- a/Source/Engine/rendering/renderers/EnvProbeRenderer.cpp
+++ b/Source/Engine/rendering/renderers/EnvProbeRenderer.cpp
@@ -668,7 +668,7 @@ void ReflectionProbeRenderer::RenderProbe(Frame* frame, const RenderSetup& rende
     View* view = renderSetup.view;
     AssertDebug(view != nullptr);
 
-    EnvProbeRendererPassData* pd = ObjCast<EnvProbeRendererPassData>(renderSetup.passData);
+    EnvProbeRendererPassData* pd = DynamicCast<EnvProbeRendererPassData>(renderSetup.passData);
     AssertDebug(pd != nullptr);
 
     RenderProxyList& rpl = GetConsumerProxyList(view);
@@ -756,7 +756,7 @@ void ReflectionProbeRenderer::RenderProbe(Frame* frame, const RenderSetup& rende
         ComputeSH(frame, envProbe);
     }
 
-    /*if (SkyProbe* skyProbe = ObjCast<SkyProbe>(envProbe))
+    /*if (SkyProbe* skyProbe = DynamicCast<SkyProbe>(envProbe))
     {
         Assert(skyProbe->GetSkyboxCubemap().IsValid());
 

--- a/Source/Engine/rendering/renderers/ParticleVolumeRenderer.cpp
+++ b/Source/Engine/rendering/renderers/ParticleVolumeRenderer.cpp
@@ -188,7 +188,7 @@ void ParticleVolumeRenderer::RenderFrame(Frame* frame, const RenderSetup& render
 
     AssertDebug(renderSetup.world && renderSetup.view && renderSetup.volume);
 
-    ParticleVolume* particleVolume = ObjCast<ParticleVolume>(renderSetup.volume);
+    ParticleVolume* particleVolume = DynamicCast<ParticleVolume>(renderSetup.volume);
     AssertDebug(particleVolume != nullptr);
 
     EnsureStaging();

--- a/Source/Engine/rendering/renderers/ShadowRenderer.cpp
+++ b/Source/Engine/rendering/renderers/ShadowRenderer.cpp
@@ -330,7 +330,7 @@ void ShadowRendererBase::RenderFrame(Frame* frame, const RenderSetup& renderSetu
             rs.framebuffer = framebuffer;
             rs.viewport = Viewport { atlasElement.dimensions, Vec2i(atlasElement.offsetCoords) };
 
-            ShadowRendererPassData* pd = ObjCast<ShadowRendererPassData>(rs.passData);
+            ShadowRendererPassData* pd = DynamicCast<ShadowRendererPassData>(rs.passData);
             AssertDebug(pd != nullptr);
 
             RenderProxyList& rpl = GetConsumerProxyList(shadowView);
@@ -417,7 +417,7 @@ void ShadowRendererBase::RenderFrame(Frame* frame, const RenderSetup& renderSetu
             rs.framebuffer = framebuffer;
             rs.viewport = Viewport { atlasElement.dimensions, Vec2i(atlasElement.offsetCoords) };
 
-            ShadowRendererPassData* pd = ObjCast<ShadowRendererPassData>(rs.passData);
+            ShadowRendererPassData* pd = DynamicCast<ShadowRendererPassData>(rs.passData);
             AssertDebug(pd != nullptr);
 
             if (needsClearBeforeDraw)

--- a/Source/Engine/rendering/renderers/SpriteRenderer.cpp
+++ b/Source/Engine/rendering/renderers/SpriteRenderer.cpp
@@ -58,6 +58,8 @@ struct TextSpriteInstanceData
     Vec4f color;
     Vec4f texcoordStart;
     Vec4f texcoordEnd;
+    uint32 textureIndex;
+    Vec2f pad;
 };
 
 struct FontAtlasCharacterIterator
@@ -69,6 +71,7 @@ struct FontAtlasCharacterIterator
     Vec2i charOffset;
 
     Vec2f glyphDimensions;
+    Vec2f glyphScaling;
 
     float bearingY;
     float charWidth;
@@ -207,7 +210,7 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
     }
 
     uint32 numSprites = 0;
-    uint32 numTextSprites = 0;
+    uint32 numTextCharacters = 0;
     for (Sprite* sprite : rpl.GetSprites())
     {
         if (!sprite)
@@ -217,7 +220,18 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
 
         if (sprite->IsA<TextSprite>())
         {
-            numTextSprites++;
+            RenderProxySprite* spriteProxy = rpl.GetSprites().GetProxy(sprite->Id());
+            if (spriteProxy && !spriteProxy->text.Empty())
+            {
+                for (size_t i = 0; i < spriteProxy->text.Length(); i++)
+                {
+                    utf::Char32 ch = spriteProxy->text.GetChar(i);
+                    if (ch != utf::Char32(' ') && ch != utf::Char32('\n'))
+                    {
+                        numTextCharacters++;
+                    }
+                }
+            }
         }
         else
         {
@@ -225,7 +239,7 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
         }
     }
 
-    if (numSprites == 0 && numTextSprites == 0)
+    if (numSprites == 0 && numTextCharacters == 0)
     {
         return;
     }
@@ -298,11 +312,10 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
         cr << DrawIndexed(quadMesh->NumIndices(), numSprites);
     }
 
-    if (numTextSprites > 0)
+    if (numTextCharacters > 0)
     {
-        StructuredBuffer& textInstanceBuffer = g_renderInterface->sbufferAllocator->AcquireBuffer(numTextSprites, sizeof(TextSpriteInstanceData));
-
-        size_t textOffset = 0;
+        Array<TextSpriteInstanceData> charData;
+        charData.Reserve(numTextCharacters);
 
         for (Sprite* sprite : rpl.GetSprites())
         {
@@ -321,21 +334,23 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
 
             const Vec3f worldPos = textSprite->GetWorldTranslation();
             const float textSize = textSprite->GetTextSize();
+            
+            const uint32 textureIndex = spriteProxy->texture ? spriteProxy->texture->Id().ToIndex() : uint32(-1);
 
             ForEachCharacter(*spriteProxy->fontAtlas, spriteProxy->text, textSize, [&](const FontAtlasCharacterIterator& iter)
                 {
-                    Transform characterTransform;
-                    characterTransform.scale = Vec3f(iter.glyphDimensions.x * textSize, iter.glyphDimensions.y * textSize, 0.01f);
-                    characterTransform.translation.y += (iter.cellDimensions.y - iter.glyphDimensions.y) * textSize;
-                    characterTransform.translation.y += iter.bearingY * textSize;
-                    characterTransform.translation += Vec3f(iter.placement.x * textSize, iter.placement.y * textSize, 0.0f);
-                    characterTransform.translation += worldPos;
+                    Vec3f charTranslation = worldPos;
+                    charTranslation.y += (iter.cellDimensions.y - iter.glyphDimensions.y) * textSize;
+                    charTranslation.y += iter.bearingY * textSize;
+                    charTranslation.x += iter.placement.x * textSize;
+                    charTranslation.y += iter.placement.y * textSize;
 
-                    Mat4f finalTransform = Mat4f::Translation(characterTransform.translation) * Mat4f::Scaling(characterTransform.scale);
+                    Mat4f finalTransform = Mat4f::Translation(charTranslation) * Mat4f::Scaling(Vec3f(iter.glyphDimensions.x * textSize, iter.glyphDimensions.y * textSize, 0.01f));
 
                     TextSpriteInstanceData data {};
                     data.transform = finalTransform;
                     data.color = Vec4f(spriteProxy->textColor);
+                    data.textureIndex = textureIndex;
 
                     Vec2f atlasPixelSize;
                     if (spriteProxy->texture && spriteProxy->texture->GetExtent().Volume() != 0)
@@ -347,9 +362,17 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
                     data.texcoordStart = Vec4f(charOffsetF * atlasPixelSize, 0.0f, 0.0f);
                     data.texcoordEnd = Vec4f((charOffsetF + (iter.glyphDimensions * 64.0f)) * atlasPixelSize, 0.0f, 0.0f);
 
-                    textInstanceBuffer.Write(textOffset, sizeof(TextSpriteInstanceData), &data);
-                    textOffset += sizeof(TextSpriteInstanceData);
+                    charData.PushBack(data);
                 });
+        }
+
+        StructuredBuffer& textInstanceBuffer = g_renderInterface->sbufferAllocator->AcquireBuffer(charData.Size(), sizeof(TextSpriteInstanceData));
+
+        size_t textOffset = 0;
+        for (const auto& data : charData)
+        {
+            textInstanceBuffer.Write(textOffset, sizeof(TextSpriteInstanceData), &data);
+            textOffset += sizeof(TextSpriteInstanceData);
         }
 
         textInstanceBuffer.Flush();
@@ -359,6 +382,7 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
 
         cr << SetCurrentShader(textShaderDesc);
 
+        // @TODO We should use one big instance buffer and use dynamic offsets to reduce the number of flushes and allocations.
         cr << SetShaderUniform(0, "TextSpriteInstanceBuffer"_sh, textInstanceBuffer.gpuBuffer);
         cr << SetShaderUniform(1, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
 
@@ -372,7 +396,7 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
         cr << BindVertexBuffer(quadMesh->GetVertexBuffer());
         cr << BindIndexBuffer(quadMesh->GetIndexBuffer());
 
-        cr << DrawIndexed(quadMesh->NumIndices(), numTextSprites);
+        cr << DrawIndexed(quadMesh->NumIndices(), charData.Size());
     }
 }
 

--- a/Source/Engine/rendering/renderers/SpriteRenderer.cpp
+++ b/Source/Engine/rendering/renderers/SpriteRenderer.cpp
@@ -18,6 +18,7 @@
 #include <rendering/Mesh.hpp>
 #include <rendering/MaterialInstance.hpp>
 #include <rendering/Shader.hpp>
+#include <rendering/Texture.hpp>
 #include <rendering/CBufferAllocator.hpp>
 #include <rendering/StructuredBufferAllocator.hpp>
 
@@ -27,7 +28,10 @@
 
 #include <scene/View.hpp>
 #include <scene/Sprite.hpp>
+#include <scene/TextSprite.hpp>
 #include <scene/camera/Camera.hpp> // Needed for .Get()
+
+#include <ui/font/FontAtlas.hpp>
 
 #include <asset/AssetRegistry.hpp>
 
@@ -41,14 +45,118 @@
 
 namespace Hyperion {
 
-HYP_DECLARE_LOG_CHANNEL(Sprite);
-
 struct SpriteInstanceData
 {
     Vec4f positionSize;
     Vec4f color;
     Vec4u flags; // x = alwaysFaceCamera
 };
+
+struct TextSpriteInstanceData
+{
+    Mat4f transform;
+    Vec4f color;
+    Vec4f texcoordStart;
+    Vec4f texcoordEnd;
+};
+
+struct FontAtlasCharacterIterator
+{
+    Vec2f placement;
+    Vec2f atlasPixelSize;
+    Vec2f cellDimensions;
+
+    Vec2i charOffset;
+
+    Vec2f glyphDimensions;
+
+    float bearingY;
+    float charWidth;
+};
+
+template <class Callback>
+static void ForEachCharacter(
+    const FontAtlas& fontAtlas,
+    const String& text,
+    float textSize,
+    Callback&& callback)
+{
+    HYP_SCOPE;
+
+    Vec2f placement = Vec2f::Zero();
+
+    const size_t length = text.Length();
+
+    const Vec2f cellDimensions = Vec2f(fontAtlas.GetCellDimensions()) / 64.0f;
+
+    const Handle<Texture>& mainTextureAtlas = fontAtlas.GetAtlasTextures().GetMainAtlas();
+    AssertDebug(mainTextureAtlas.IsValid(), "Main texture atlas is invalid");
+
+    if (!mainTextureAtlas.IsValid())
+    {
+        return;
+    }
+
+    Vec2f atlasPixelSize;
+
+    if (mainTextureAtlas->GetExtent().Volume() != 0)
+    {
+        atlasPixelSize = Vec2f::One() / Vec2f(mainTextureAtlas->GetExtent().GetXY());
+    }
+
+    Array<FontAtlasCharacterIterator> currentWordChars;
+
+    const auto iterateCurrentWord = [&currentWordChars, &callback]()
+    {
+        for (const FontAtlasCharacterIterator& characterIterator : currentWordChars)
+        {
+            callback(characterIterator);
+        }
+
+        currentWordChars.Clear();
+    };
+
+    for (size_t i = 0; i < length; i++)
+    {
+        const utf::Char32 ch = text.GetChar(i);
+
+        if (ch == utf::Char32(' '))
+        {
+            placement.x += cellDimensions.x * 0.5f;
+            iterateCurrentWord();
+            continue;
+        }
+
+        if (ch == utf::Char32('\n'))
+        {
+            placement.x = 0.0f;
+            placement.y += cellDimensions.y;
+            iterateCurrentWord();
+            continue;
+        }
+
+        Optional<const GlyphMetrics&> glyphMetrics = fontAtlas.GetGlyphMetricsForChar(ch);
+
+        if (!glyphMetrics.HasValue() || (glyphMetrics->width == 0 || glyphMetrics->height == 0))
+        {
+            HYP_LOG_ONCE(Rendering, Warning, "Ensure how to render char: {}", (int)ch);
+            continue;
+        }
+
+        FontAtlasCharacterIterator& characterIterator = currentWordChars.EmplaceBack();
+        characterIterator.placement = placement;
+        characterIterator.atlasPixelSize = atlasPixelSize;
+        characterIterator.cellDimensions = cellDimensions;
+        characterIterator.charOffset = glyphMetrics->imagePosition;
+        characterIterator.glyphDimensions = Vec2f(float(glyphMetrics->width), float(glyphMetrics->height)) / 64.0f;
+        characterIterator.bearingY = float(glyphMetrics->height - glyphMetrics->bearingY) / 64.0f;
+        characterIterator.charWidth = float(glyphMetrics->advance / 64) / 64.0f;
+
+        placement.x += characterIterator.charWidth;
+    }
+
+    iterateCurrentWord();
+}
 
 #pragma region SpriteRenderer
 
@@ -99,23 +207,7 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
     }
 
     uint32 numSprites = 0;
-    for (Sprite* sprite : rpl.GetSprites())
-    {
-        if (sprite)
-        {
-            numSprites++;
-        }
-    }
-
-    if (numSprites == 0)
-    {
-        return;
-    }
-
-    StructuredBuffer& instanceBuffer = g_renderInterface->sbufferAllocator->AcquireBuffer(numSprites, sizeof(SpriteInstanceData));
-
-    size_t offset = 0;
-
+    uint32 numTextSprites = 0;
     for (Sprite* sprite : rpl.GetSprites())
     {
         if (!sprite)
@@ -123,22 +215,20 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
             continue;
         }
 
-        RenderProxySprite* spriteProxy = rpl.GetSprites().GetProxy(sprite->Id());
-        if (!spriteProxy)
+        if (sprite->IsA<TextSprite>())
         {
-            continue;
+            numTextSprites++;
         }
-
-        SpriteInstanceData data {};
-        data.positionSize = Vec4f(sprite->GetWorldTranslation(), sprite->size);
-        data.color = Vec4f(sprite->color);
-        data.flags = Vec4u(spriteProxy->bufferData.alwaysFaceCamera, 0u, 0u, 0u);
-
-        instanceBuffer.Write(offset, sizeof(SpriteInstanceData), &data);
-        offset += sizeof(SpriteInstanceData);
+        else
+        {
+            numSprites++;
+        }
     }
 
-    instanceBuffer.Flush();
+    if (numSprites == 0 && numTextSprites == 0)
+    {
+        return;
+    }
 
     CommandRecorder& cr = frame->cr;
     View* view = renderSetup.view;
@@ -157,25 +247,133 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
     cr << SetTopology(Topology::TOP_TRIANGLES);
     cr << SetInputLayout(StaticVertexInputLayout<VT_Simple>);
 
-    ShaderDesc shaderDesc;
-    shaderDesc.name = NAME("Sprite");
+    if (numSprites > 0)
+    {
+        StructuredBuffer& instanceBuffer = g_renderInterface->sbufferAllocator->AcquireBuffer(numSprites, sizeof(SpriteInstanceData));
 
-    cr << SetCurrentShader(shaderDesc);
+        size_t offset = 0;
 
-    cr << SetShaderUniform(0, "SpriteInstanceBuffer"_sh, instanceBuffer.gpuBuffer);
-    cr << SetShaderUniform(1, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
+        for (Sprite* sprite : rpl.GetSprites())
+        {
+            if (!sprite || sprite->IsA<TextSprite>())
+            {
+                continue;
+            }
 
-    cr << SetCurrentBlendFunction(BlendFunction::AlphaBlending()); // @TODO premul?
-    cr << SetDepthTest(true);
-    cr << SetDepthWrite(false);
-    cr << SetFaceCullMode(FaceCullMode::FCM_NONE);
+            RenderProxySprite* spriteProxy = rpl.GetSprites().GetProxy(sprite->Id());
+            if (!spriteProxy)
+            {
+                continue;
+            }
 
-    cr << CommitDrawState();
+            SpriteInstanceData data {};
+            data.positionSize = Vec4f(sprite->GetWorldTranslation(), sprite->size);
+            data.color = Vec4f(sprite->color);
+            data.flags = Vec4u(spriteProxy->bufferData.alwaysFaceCamera, 0u, 0u, 0u);
 
-    cr << BindVertexBuffer(quadMesh->GetVertexBuffer());
-    cr << BindIndexBuffer(quadMesh->GetIndexBuffer());
+            instanceBuffer.Write(offset, sizeof(SpriteInstanceData), &data);
+            offset += sizeof(SpriteInstanceData);
+        }
 
-    cr << DrawIndexed(quadMesh->NumIndices(), numSprites);
+        instanceBuffer.Flush();
+
+        ShaderDesc shaderDesc;
+        shaderDesc.name = NAME("Sprite");
+
+        cr << SetCurrentShader(shaderDesc);
+
+        cr << SetShaderUniform(0, "SpriteInstanceBuffer"_sh, instanceBuffer.gpuBuffer);
+        cr << SetShaderUniform(1, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
+
+        cr << SetCurrentBlendFunction(BlendFunction::AlphaBlending());
+        cr << SetDepthTest(true);
+        cr << SetDepthWrite(false);
+        cr << SetFaceCullMode(FaceCullMode::FCM_NONE);
+
+        cr << CommitDrawState();
+
+        cr << BindVertexBuffer(quadMesh->GetVertexBuffer());
+        cr << BindIndexBuffer(quadMesh->GetIndexBuffer());
+
+        cr << DrawIndexed(quadMesh->NumIndices(), numSprites);
+    }
+
+    if (numTextSprites > 0)
+    {
+        StructuredBuffer& textInstanceBuffer = g_renderInterface->sbufferAllocator->AcquireBuffer(numTextSprites, sizeof(TextSpriteInstanceData));
+
+        size_t textOffset = 0;
+
+        for (Sprite* sprite : rpl.GetSprites())
+        {
+            if (!sprite || !sprite->IsA<TextSprite>())
+            {
+                continue;
+            }
+
+            TextSprite* textSprite = static_cast<TextSprite*>(sprite);
+
+            RenderProxySprite* spriteProxy = rpl.GetSprites().GetProxy(textSprite->Id());
+            if (!spriteProxy || !spriteProxy->fontAtlas)
+            {
+                continue;
+            }
+
+            const Vec3f worldPos = textSprite->GetWorldTranslation();
+            const float textSize = textSprite->GetTextSize();
+
+            ForEachCharacter(*spriteProxy->fontAtlas, spriteProxy->text, textSize, [&](const FontAtlasCharacterIterator& iter)
+                {
+                    Transform characterTransform;
+                    characterTransform.scale = Vec3f(iter.glyphDimensions.x * textSize, iter.glyphDimensions.y * textSize, 0.01f);
+                    characterTransform.translation.y += (iter.cellDimensions.y - iter.glyphDimensions.y) * textSize;
+                    characterTransform.translation.y += iter.bearingY * textSize;
+                    characterTransform.translation += Vec3f(iter.placement.x * textSize, iter.placement.y * textSize, 0.0f);
+                    characterTransform.translation += worldPos;
+
+                    Mat4f finalTransform = Mat4f::Translation(characterTransform.translation) * Mat4f::Scaling(characterTransform.scale);
+
+                    TextSpriteInstanceData data {};
+                    data.transform = finalTransform;
+                    data.color = Vec4f(spriteProxy->textColor);
+
+                    Vec2f atlasPixelSize;
+                    if (spriteProxy->texture && spriteProxy->texture->GetExtent().Volume() != 0)
+                    {
+                        atlasPixelSize = Vec2f::One() / Vec2f(spriteProxy->texture->GetExtent().GetXY());
+                    }
+
+                    Vec2f charOffsetF = Vec2f(iter.charOffset);
+                    data.texcoordStart = Vec4f(charOffsetF * atlasPixelSize, 0.0f, 0.0f);
+                    data.texcoordEnd = Vec4f((charOffsetF + (iter.glyphDimensions * 64.0f)) * atlasPixelSize, 0.0f, 0.0f);
+
+                    textInstanceBuffer.Write(textOffset, sizeof(TextSpriteInstanceData), &data);
+                    textOffset += sizeof(TextSpriteInstanceData);
+                });
+        }
+
+        textInstanceBuffer.Flush();
+
+        ShaderDesc textShaderDesc;
+        textShaderDesc.name = NAME("TextSprite");
+
+        cr << SetCurrentShader(textShaderDesc);
+
+        cr << SetShaderUniform(0, "TextSpriteInstanceBuffer"_sh, textInstanceBuffer.gpuBuffer);
+        cr << SetShaderUniform(1, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
+
+        cr << SetCurrentBlendFunction(BlendFunction::AlphaBlending());
+        cr << SetDepthTest(true);
+        cr << SetDepthWrite(false);
+        cr << SetFaceCullMode(FaceCullMode::FCM_NONE);
+
+        cr << CommitDrawState();
+
+        cr << BindVertexBuffer(quadMesh->GetVertexBuffer());
+        cr << BindIndexBuffer(quadMesh->GetIndexBuffer());
+
+        cr << DrawIndexed(quadMesh->NumIndices(), numTextSprites);
+    }
 }
 
 PassData* SpriteRenderer::CreateViewPassData(View* view, PassDataExt&)

--- a/Source/Engine/rendering/renderers/SpriteRenderer.cpp
+++ b/Source/Engine/rendering/renderers/SpriteRenderer.cpp
@@ -35,7 +35,7 @@
 
 #include <engine/EngineDriver.hpp>
 #include <engine/CVarManager.hpp>
-#include <Engine/EngineGlobals.hpp>
+#include <engine/EngineGlobals.hpp>
 
 #include <SpriteRenderer.generated.inl>
 

--- a/Source/Engine/rendering/renderers/SpriteRenderer.cpp
+++ b/Source/Engine/rendering/renderers/SpriteRenderer.cpp
@@ -77,6 +77,63 @@ struct FontAtlasCharacterIterator
     float charWidth;
 };
 
+struct TextMetrics
+{
+    Vec2f size;
+};
+
+static TextMetrics MeasureText(
+    const FontAtlas& fontAtlas,
+    const String& text,
+    float textSize)
+{
+    HYP_SCOPE;
+
+    Vec2f placement = Vec2f::Zero();
+    Vec2f totalSize = Vec2f::Zero();
+
+    const size_t length = text.Length();
+    const Vec2f cellDimensions = Vec2f(fontAtlas.GetCellDimensions()) / 64.0f;
+
+    for (size_t i = 0; i < length; i++)
+    {
+        const utf::Char32 ch = text.GetChar(i);
+
+        if (ch == utf::Char32(' '))
+        {
+            placement.x += cellDimensions.x * 0.5f;
+            continue;
+        }
+
+        if (ch == utf::Char32('\n'))
+        {
+            totalSize.x = MathUtil::Max(totalSize.x, placement.x);
+            placement.x = 0.0f;
+            placement.y += cellDimensions.y;
+            continue;
+        }
+
+        Optional<const GlyphMetrics&> glyphMetrics = fontAtlas.GetGlyphMetricsForChar(ch);
+        if (!glyphMetrics.HasValue() || (glyphMetrics->width == 0 || glyphMetrics->height == 0))
+        {
+            continue;
+        }
+
+        const Vec2f glyphDimensions = Vec2f(float(glyphMetrics->width), float(glyphMetrics->height)) / 64.0f;
+        const float charWidth = float(glyphMetrics->advance / 64) / 64.0f;
+        const float bearingY = float(glyphMetrics->height - glyphMetrics->bearingY) / 64.0f;
+
+        const float charHeight = glyphDimensions.y + bearingY;
+        totalSize.y = MathUtil::Max(totalSize.y, placement.y + charHeight);
+
+        placement.x += charWidth;
+    }
+
+    totalSize.x = MathUtil::Max(totalSize.x, placement.x);
+
+    return { totalSize * textSize };
+}
+
 template <class Callback>
 static void ForEachCharacter(
     const FontAtlas& fontAtlas,
@@ -362,18 +419,20 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
 
             const Vec3f worldPos = sprite->GetWorldTranslation(); // spriteProxy->bufferData.positionSize.GetXYZ();
             const float textSize = spriteProxy->bufferData.positionSize.w;
-            
+
             const uint32 textureIndex = spriteProxy->texture ? spriteProxy->texture->Id().ToIndex() : uint32(-1);
+
+            const TextMetrics metrics = MeasureText(*spriteProxy->fontAtlas, spriteProxy->text, textSize);
 
             ForEachCharacter(*spriteProxy->fontAtlas, spriteProxy->text, textSize, [&](const FontAtlasCharacterIterator& iter)
                 {
                     const float scaleX = iter.glyphDimensions.x * textSize;
                     const float scaleY = iter.glyphDimensions.y * textSize;
 
-                    const float offsetY = ((iter.cellDimensions.y - iter.glyphDimensions.y) + iter.bearingY) * textSize;
+                    const float offsetY = -iter.bearingY * textSize;
                     const Vec3f charTranslation(
-                        worldPos.x + iter.placement.x * textSize,
-                        worldPos.y + iter.placement.y * textSize + offsetY,
+                        worldPos.x + iter.placement.x * textSize - metrics.size.x * 0.5f,
+                        worldPos.y + iter.placement.y * textSize + offsetY - metrics.size.y * 0.5f,
                         worldPos.z
                     );
 

--- a/Source/Engine/rendering/renderers/SpriteRenderer.cpp
+++ b/Source/Engine/rendering/renderers/SpriteRenderer.cpp
@@ -47,6 +47,7 @@ struct SpriteInstanceData
 {
     Vec4f positionSize;
     Vec4f color;
+    Vec4u flags; // x = alwaysFaceCamera
 };
 
 #pragma region SpriteRenderer
@@ -131,6 +132,7 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
         SpriteInstanceData data {};
         data.positionSize = Vec4f(sprite->GetWorldTranslation(), sprite->size);
         data.color = Vec4f(sprite->color);
+        data.flags = Vec4u(spriteProxy->bufferData.alwaysFaceCamera, 0u, 0u, 0u);
 
         instanceBuffer.Write(offset, sizeof(SpriteInstanceData), &data);
         offset += sizeof(SpriteInstanceData);

--- a/Source/Engine/rendering/renderers/SpriteRenderer.cpp
+++ b/Source/Engine/rendering/renderers/SpriteRenderer.cpp
@@ -1,0 +1,177 @@
+/*!
+ *  @author: The Hyperion Contributors
+ *  @date 2016-2026
+ *  @licence MIT
+ */
+
+#include <RenderingPch.hpp>
+
+#include <rendering/RenderInterface.hpp>
+#include <rendering/RenderConfig.hpp>
+#include <rendering/RenderProxyList.hpp>
+#include <rendering/RenderProxy.hpp>
+#include <rendering/GBuffer.hpp>
+#include <rendering/Buffers.hpp>
+#include <rendering/PlaceholderData.hpp>
+#include <rendering/ShaderManager.hpp>
+#include <rendering/Frame.hpp>
+#include <rendering/Mesh.hpp>
+#include <rendering/MaterialInstance.hpp>
+#include <rendering/Shader.hpp>
+#include <rendering/StructuredBufferAllocator.hpp>
+
+#include <rendering/renderers/SpriteRenderer.hpp>
+
+#include <util/MeshBuilder.hpp>
+
+#include <scene/View.hpp>
+#include <scene/Sprite.hpp>
+
+#include <asset/AssetRegistry.hpp>
+
+#include <Core/utilities/DeferredScope.hpp>
+
+#include <engine/EngineDriver.hpp>
+#include <engine/CVarManager.hpp>
+#include <Engine/EngineGlobals.hpp>
+
+#include <SpriteRenderer.generated.inl>
+
+namespace Hyperion {
+
+HYP_DECLARE_LOG_CHANNEL(Sprite);
+
+struct SpriteInstanceData
+{
+    Vec4f positionSize;
+    Vec4f color;
+};
+
+#pragma region SpriteRenderer
+
+SpriteRenderer::SpriteRenderer()
+{
+}
+
+void SpriteRenderer::Initialize()
+{
+    m_quadMesh = MeshBuilder::Cube(); // Quad();
+    m_quadMesh->SetName(NAME("SpriteMesh"));
+    m_quadMesh->SetFlags(MeshFlags::ViewIndependent);
+    m_quadMesh->SetIsTransient(true);
+    InitObject(m_quadMesh);
+
+    GetEngineAssetRegistry()->PutAsset(m_quadMesh);
+}
+
+void SpriteRenderer::Shutdown()
+{
+    EnqueueDeletion(std::move(m_quadMesh));
+}
+
+void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
+{
+    HYP_SCOPE;
+    AssertOnThread(g_renderThread);
+
+    Assert(renderSetup.view != nullptr);
+
+    SpriteRendererPassData* pd = DynamicCast<SpriteRendererPassData>(FetchViewPassData(renderSetup.view));
+    AssertDebug(pd != nullptr);
+
+    RenderProxyList& rpl = GetConsumerProxyList(renderSetup.view);
+    rpl.BeginRead();
+    HYP_DEFER({ rpl.EndRead(); });
+
+    if (!rpl.GetSprites().NumCurrent())
+    {
+        return;
+    }
+
+    Mesh* quadMesh = m_quadMesh;
+
+    if (!quadMesh)
+    {
+        return;
+    }
+
+    uint32 numSprites = 0;
+    for (Sprite* sprite : rpl.GetSprites())
+    {
+        if (sprite)
+        {
+            numSprites++;
+        }
+    }
+
+    if (numSprites == 0)
+    {
+        return;
+    }
+
+    StructuredBuffer& instanceBuffer = g_renderInterface->sbufferAllocator->AcquireBuffer(numSprites, sizeof(SpriteInstanceData));
+
+    size_t offset = 0;
+
+    for (Sprite* sprite : rpl.GetSprites())
+    {
+        if (!sprite)
+        {
+            continue;
+        }
+
+        RenderProxySprite* spriteProxy = rpl.GetSprites().GetProxy(sprite->Id());
+        if (!spriteProxy)
+        {
+            continue;
+        }
+
+        SpriteInstanceData data {};
+        data.positionSize = Vec4f(sprite->GetWorldTranslation(), sprite->size);
+        data.color = Vec4f(sprite->color);
+
+        instanceBuffer.Write(offset, sizeof(SpriteInstanceData), &data);
+        offset += sizeof(SpriteInstanceData);
+    }
+
+    instanceBuffer.Flush();
+
+    CommandRecorder& cr = frame->cr;
+    View* view = renderSetup.view;
+
+    cr << SetCurrentViewport(renderSetup.viewport);
+    cr << SetTopology(Topology::TOP_TRIANGLES);
+    cr << SetInputLayout(StaticVertexInputLayout<VT_Simple>);
+
+    ShaderDesc shaderDesc;
+    shaderDesc.name = NAME("Sprite");
+
+    cr << SetCurrentShader(shaderDesc);
+
+    cr << SetShaderUniform(0, "SpriteInstanceBuffer"_sh, instanceBuffer.gpuBuffer);
+
+    cr << SetCurrentBlendFunction(BlendFunction::AlphaBlending()); // @TODO premul?
+    cr << SetDepthTest(true);
+    cr << SetDepthWrite(false);
+    cr << SetFaceCullMode(FaceCullMode::FCM_NONE);
+
+    cr << CommitDrawState();
+
+    cr << BindVertexBuffer(quadMesh->GetVertexBuffer());
+    cr << BindIndexBuffer(quadMesh->GetIndexBuffer());
+
+    cr << DrawIndexed(quadMesh->NumIndices(), numSprites);
+}
+
+PassData* SpriteRenderer::CreateViewPassData(View* view, PassDataExt&)
+{
+    SpriteRendererPassData* pd = new SpriteRendererPassData();
+
+    pd->view = MakeWeakRef(view);
+
+    return pd;
+}
+
+#pragma endregion SpriteRenderer
+
+} // namespace Hyperion

--- a/Source/Engine/rendering/renderers/SpriteRenderer.cpp
+++ b/Source/Engine/rendering/renderers/SpriteRenderer.cpp
@@ -52,14 +52,13 @@ struct SpriteInstanceData
     Vec4u flags; // x = alwaysFaceCamera
 };
 
-struct TextSpriteInstanceData
+struct alignas(16) TextSpriteInstanceData
 {
     Mat4f transform;
-    Vec4f color;
-    Vec4f texcoordStart;
-    Vec4f texcoordEnd;
+    Vec2f texcoordStart;
+    Vec2f texcoordEnd;
     uint32 textureIndex;
-    Vec2f pad;
+    uint32 colorPacked;
 };
 
 struct FontAtlasCharacterIterator
@@ -295,9 +294,10 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
         shaderDesc.name = NAME("Sprite");
 
         cr << SetCurrentShader(shaderDesc);
-
-        cr << SetShaderUniform(0, "SpriteInstanceBuffer"_sh, instanceBuffer.gpuBuffer);
-        cr << SetShaderUniform(1, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
+        
+        cr << SetShaderUniform(0, "SamplerLinear"_sh, g_renderInterface->placeholderData->GetSamplerLinear());
+        cr << SetShaderUniform(1, "SpriteInstanceBuffer"_sh, instanceBuffer.gpuBuffer);
+        cr << SetShaderUniform(2, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
 
         cr << SetCurrentBlendFunction(BlendFunction::AlphaBlending());
         cr << SetDepthTest(true);
@@ -332,8 +332,8 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
                 continue;
             }
 
-            const Vec3f worldPos = textSprite->GetWorldTranslation();
-            const float textSize = textSprite->GetTextSize();
+            const Vec3f worldPos = spriteProxy->bufferData.positionSize.GetXYZ();
+            const float textSize = spriteProxy->bufferData.positionSize.w;
             
             const uint32 textureIndex = spriteProxy->texture ? spriteProxy->texture->Id().ToIndex() : uint32(-1);
 
@@ -345,12 +345,21 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
                     charTranslation.x += iter.placement.x * textSize;
                     charTranslation.y += iter.placement.y * textSize;
 
-                    Mat4f finalTransform = Mat4f::Translation(charTranslation) * Mat4f::Scaling(Vec3f(iter.glyphDimensions.x * textSize, iter.glyphDimensions.y * textSize, 0.01f));
+                    const float scaleX = iter.glyphDimensions.x * textSize;
+                    const float scaleY = iter.glyphDimensions.y * textSize;
 
                     TextSpriteInstanceData data {};
-                    data.transform = finalTransform;
-                    data.color = Vec4f(spriteProxy->textColor);
+
+                    data.transform = Mat4f::Identity();
+                    data.transform[0][0] = scaleX;
+                    data.transform[1][1] = scaleY;
+                    data.transform[2][2] = 0.01f;
+                    data.transform[0][3] = charTranslation.x;
+                    data.transform[1][3] = charTranslation.y;
+                    data.transform[2][3] = charTranslation.z;
+
                     data.textureIndex = textureIndex;
+                    data.colorPacked = spriteProxy->textColor.Packed();
 
                     Vec2f atlasPixelSize;
                     if (spriteProxy->texture && spriteProxy->texture->GetExtent().Volume() != 0)
@@ -359,8 +368,8 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
                     }
 
                     Vec2f charOffsetF = Vec2f(iter.charOffset);
-                    data.texcoordStart = Vec4f(charOffsetF * atlasPixelSize, 0.0f, 0.0f);
-                    data.texcoordEnd = Vec4f((charOffsetF + (iter.glyphDimensions * 64.0f)) * atlasPixelSize, 0.0f, 0.0f);
+                    data.texcoordStart = Vec2f(charOffsetF * atlasPixelSize);
+                    data.texcoordEnd = Vec2f((charOffsetF + (iter.glyphDimensions * 64.0f)) * atlasPixelSize);
 
                     charData.PushBack(data);
                 });
@@ -382,9 +391,9 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
 
         cr << SetCurrentShader(textShaderDesc);
 
-        // @TODO We should use one big instance buffer and use dynamic offsets to reduce the number of flushes and allocations.
-        cr << SetShaderUniform(0, "TextSpriteInstanceBuffer"_sh, textInstanceBuffer.gpuBuffer);
-        cr << SetShaderUniform(1, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
+        cr << SetShaderUniform(0, "SamplerLinear"_sh, g_renderInterface->placeholderData->GetSamplerLinear());
+        cr << SetShaderUniform(1, "TextSpriteInstanceBuffer"_sh, textInstanceBuffer.gpuBuffer);
+        cr << SetShaderUniform(2, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
 
         cr << SetCurrentBlendFunction(BlendFunction::AlphaBlending());
         cr << SetDepthTest(true);

--- a/Source/Engine/rendering/renderers/SpriteRenderer.cpp
+++ b/Source/Engine/rendering/renderers/SpriteRenderer.cpp
@@ -21,6 +21,7 @@
 #include <rendering/Texture.hpp>
 #include <rendering/CBufferAllocator.hpp>
 #include <rendering/StructuredBufferAllocator.hpp>
+#include <rendering/SamplerCache.hpp>
 
 #include <rendering/renderers/SpriteRenderer.hpp>
 
@@ -168,10 +169,37 @@ SpriteRenderer::SpriteRenderer()
 
 void SpriteRenderer::Initialize()
 {
-    m_quadMesh = MeshBuilder::Cube(); // Quad();
+    m_quadMesh = MeshBuilder::Quad();
     m_quadMesh->SetName(NAME("SpriteMesh"));
     m_quadMesh->SetFlags(MeshFlags::ViewIndependent);
     m_quadMesh->SetIsTransient(true);
+
+    {
+        VertexArrayView vd = m_quadMesh->GetVertexData();
+        ByteView id = m_quadMesh->GetIndexData();
+
+        Array<SimpleVertex> newVertices;
+        newVertices.Resize(vd.vertexCount);
+        Memory::Copy(newVertices.Data(), vd.floatData, vd.vertexCount * sizeof(SimpleVertex));
+
+        for (SimpleVertex& vert : newVertices)
+        {
+            vert.posX = (vert.posX + 1.0f) * 0.5f;
+            vert.posY = (vert.posY + 1.0f) * 0.5f;
+        }
+
+        VertexArrayView vertexArrayView {};
+        vertexArrayView.floatData = reinterpret_cast<const float*>(newVertices.Data());
+        vertexArrayView.vertexCount = newVertices.Size();
+        vertexArrayView.layoutDesc = { VT_Simple };
+
+        Array<ubyte> indexData;
+        indexData.Resize(id.Size());
+        Memory::Copy(indexData.Data(), id.Data(), id.Size());
+
+        m_quadMesh->SetMeshData(m_quadMesh->GetMeshDesc(), vertexArrayView, indexData);
+    }
+
     InitObject(m_quadMesh);
 
     GetEngineAssetRegistry()->PutAsset(m_quadMesh);
@@ -332,31 +360,30 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
                 continue;
             }
 
-            const Vec3f worldPos = spriteProxy->bufferData.positionSize.GetXYZ();
+            const Vec3f worldPos = sprite->GetWorldTranslation(); // spriteProxy->bufferData.positionSize.GetXYZ();
             const float textSize = spriteProxy->bufferData.positionSize.w;
             
             const uint32 textureIndex = spriteProxy->texture ? spriteProxy->texture->Id().ToIndex() : uint32(-1);
 
             ForEachCharacter(*spriteProxy->fontAtlas, spriteProxy->text, textSize, [&](const FontAtlasCharacterIterator& iter)
                 {
-                    Vec3f charTranslation = worldPos;
-                    charTranslation.y += (iter.cellDimensions.y - iter.glyphDimensions.y) * textSize;
-                    charTranslation.y += iter.bearingY * textSize;
-                    charTranslation.x += iter.placement.x * textSize;
-                    charTranslation.y += iter.placement.y * textSize;
-
                     const float scaleX = iter.glyphDimensions.x * textSize;
                     const float scaleY = iter.glyphDimensions.y * textSize;
 
+                    const float offsetY = ((iter.cellDimensions.y - iter.glyphDimensions.y) + iter.bearingY) * textSize;
+                    const Vec3f charTranslation(
+                        worldPos.x + iter.placement.x * textSize,
+                        worldPos.y + iter.placement.y * textSize + offsetY,
+                        worldPos.z
+                    );
+
                     TextSpriteInstanceData data {};
 
-                    data.transform = Mat4f::Identity();
-                    data.transform[0][0] = scaleX;
-                    data.transform[1][1] = scaleY;
-                    data.transform[2][2] = 0.01f;
-                    data.transform[0][3] = charTranslation.x;
-                    data.transform[1][3] = charTranslation.y;
-                    data.transform[2][3] = charTranslation.z;
+                    Transform t;
+                    t.SetScale(Vec3f(scaleX, scaleY, 0.1f));
+                    t.SetTranslation(charTranslation);
+
+                    data.transform = t.GetMatrix();
 
                     data.textureIndex = textureIndex;
                     data.colorPacked = spriteProxy->textColor.Packed();
@@ -386,12 +413,20 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
 
         textInstanceBuffer.Flush();
 
+        static Sampler* s_textSpriteSampler = g_renderInterface->samplerCache->GetOrCreate(SamplerDesc {
+            TFM_LINEAR,
+            TFM_LINEAR,
+            TWM_CLAMP_TO_EDGE,
+            SamplerCompareOp::None
+        });
+
         ShaderDesc textShaderDesc;
         textShaderDesc.name = NAME("TextSprite");
 
         cr << SetCurrentShader(textShaderDesc);
 
-        cr << SetShaderUniform(0, "SamplerLinear"_sh, g_renderInterface->placeholderData->GetSamplerLinear());
+        cr << SetShaderUniform(0, "SamplerLinear"_sh, s_textSpriteSampler);
+
         cr << SetShaderUniform(1, "TextSpriteInstanceBuffer"_sh, textInstanceBuffer.gpuBuffer);
         cr << SetShaderUniform(2, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
 

--- a/Source/Engine/rendering/renderers/SpriteRenderer.cpp
+++ b/Source/Engine/rendering/renderers/SpriteRenderer.cpp
@@ -18,6 +18,7 @@
 #include <rendering/Mesh.hpp>
 #include <rendering/MaterialInstance.hpp>
 #include <rendering/Shader.hpp>
+#include <rendering/CBufferAllocator.hpp>
 #include <rendering/StructuredBufferAllocator.hpp>
 
 #include <rendering/renderers/SpriteRenderer.hpp>
@@ -26,6 +27,7 @@
 
 #include <scene/View.hpp>
 #include <scene/Sprite.hpp>
+#include <scene/camera/Camera.hpp> // Needed for .Get()
 
 #include <asset/AssetRegistry.hpp>
 
@@ -139,6 +141,16 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
     CommandRecorder& cr = frame->cr;
     View* view = renderSetup.view;
 
+    RenderProxyCamera* cameraProxy = static_cast<RenderProxyCamera*>(GetRenderProxy(view->GetCamera().Get()));
+    Assert(cameraProxy != nullptr);
+
+    GpuBuffer* cbuffer = nullptr;
+    size_t cbufferOffset = 0;
+    size_t cbufferSize = 0;
+
+    g_renderInterface->cbufferAllocator->Write(&cameraProxy->bufferData);
+    g_renderInterface->cbufferAllocator->Commit(cbuffer, cbufferOffset, cbufferSize);
+
     cr << SetCurrentViewport(renderSetup.viewport);
     cr << SetTopology(Topology::TOP_TRIANGLES);
     cr << SetInputLayout(StaticVertexInputLayout<VT_Simple>);
@@ -149,6 +161,7 @@ void SpriteRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
     cr << SetCurrentShader(shaderDesc);
 
     cr << SetShaderUniform(0, "SpriteInstanceBuffer"_sh, instanceBuffer.gpuBuffer);
+    cr << SetShaderUniform(1, "CBuffer"_sh, cbuffer, ShaderDataOffset(cbufferOffset, cbufferSize));
 
     cr << SetCurrentBlendFunction(BlendFunction::AlphaBlending()); // @TODO premul?
     cr << SetDepthTest(true);

--- a/Source/Engine/rendering/renderers/SpriteRenderer.hpp
+++ b/Source/Engine/rendering/renderers/SpriteRenderer.hpp
@@ -1,0 +1,47 @@
+/*!
+ *  @author: The Hyperion Contributors
+ *  @date 2016-2026
+ *  @licence MIT
+ */
+
+#pragma once
+
+#include <Core/memory/resource/Resource.hpp>
+
+#include <rendering/RendererBase.hpp>
+#include <rendering/RenderObject.hpp>
+
+#include <scene/Subsystem.hpp>
+
+namespace Hyperion {
+
+class View;
+struct RenderSetup;
+
+HYP_CLASS(NoScriptBindings)
+class HYP_API SpriteRendererPassData : public PassData
+{
+    HYP_OBJECT_BODY(SpriteRendererPassData);
+
+public:
+    virtual ~SpriteRendererPassData() override = default;
+};
+
+class SpriteRenderer final : public RendererBase
+{
+public:
+    SpriteRenderer();
+    virtual ~SpriteRenderer() = default;
+
+    virtual void Initialize() override;
+    virtual void Shutdown() override;
+
+    virtual void RenderFrame(Frame* frame, const RenderSetup& renderSetup) override;
+
+protected:
+    PassData* CreateViewPassData(View* view, PassDataExt&) override;
+
+    Handle<Mesh> m_quadMesh;
+};
+
+} // namespace Hyperion

--- a/Source/Engine/rendering/renderers/UIRenderer.cpp
+++ b/Source/Engine/rendering/renderers/UIRenderer.cpp
@@ -6,7 +6,6 @@
 
 #include <RenderingPch.hpp>
 
-#include <rendering/RenderGroup.hpp>
 #include <rendering/RenderInterface.hpp>
 #include <rendering/RenderConfig.hpp>
 #include <rendering/RenderProxyList.hpp>
@@ -19,6 +18,7 @@
 #include <rendering/Frame.hpp>
 #include <rendering/Mesh.hpp>
 #include <rendering/MaterialInstance.hpp>
+#include <rendering/RenderGroup.hpp>
 #include <rendering/RenderGroupCache.hpp>
 
 #include <rendering/renderers/DeferredRenderer.hpp>
@@ -258,7 +258,7 @@ void UIRenderer::RenderFrame(Frame* frame, const RenderSetup& renderSetup)
 
     Assert(renderSetup.view != nullptr);
 
-    UIRendererPassData* pd = ObjCast<UIRendererPassData>(FetchViewPassData(renderSetup.view));
+    UIRendererPassData* pd = DynamicCast<UIRendererPassData>(FetchViewPassData(renderSetup.view));
     AssertDebug(pd != nullptr);
 
     if (!pd->renderCollector.batchAllocator)

--- a/Source/Engine/rendering/renderers/UIRenderer.cpp
+++ b/Source/Engine/rendering/renderers/UIRenderer.cpp
@@ -138,6 +138,7 @@ static void BuildRenderGroupsOrdered(
             drawCallCollection.batchAllocator = renderCollector.batchAllocator;
 
             drawCallCollection.isInit = true;
+            drawCallCollection.suppressStats = true;
         }
 
         drawCallCollection.meshProxies.Set(meshProxy->entity.Id().ToIndex(), meshProxy);

--- a/Source/Engine/rendering/resources/ResourceBindings.cpp
+++ b/Source/Engine/rendering/resources/ResourceBindings.cpp
@@ -251,10 +251,12 @@ void OnBindingChanged_Texture(Texture* texture, uint32 prev, uint32 next)
     {
         if (next != ~0u)
         {
+            // @TODO Use 'next' rather than texture->Id().ToIndex() here
             g_renderInterface->bindlessStorage->AddResource(BindlessStorage_Textures, texture->Id().ToIndex(), g_renderInterface->textureViewCache->GetOrCreate(texture));
         }
         else
         {
+            // @TODO Use 'prev' rather than texture->Id().ToIndex() here
             g_renderInterface->bindlessStorage->RemoveResource(BindlessStorage_Textures, texture->Id().ToIndex());
         }
     }

--- a/Source/Engine/rendering/resources/ResourceBindings.inl
+++ b/Source/Engine/rendering/resources/ResourceBindings.inl
@@ -87,6 +87,10 @@ static ResourceBindingAllocator<MaxBoundSkeletons> s_skeletonBindingsAllocator;
 static ResourceBinder<Skeleton> s_skeletonBinder { &s_skeletonBindingsAllocator };
 ResourceBinderBase* g_skeletonBinder = &s_skeletonBinder;
 
+static ResourceBindingAllocator<MaxBoundSprites> s_spriteBindingsAllocator;
+static ResourceBinder<Sprite> s_spriteBinder { &s_spriteBindingsAllocator };
+ResourceBinderBase* g_spriteBinder = &s_spriteBinder;
+
 static ResourceBinderBase* s_resourceBinders[] = {
     &s_meshEntityBinder,
     &s_meshBinder,
@@ -100,5 +104,6 @@ static ResourceBinderBase* s_resourceBinders[] = {
     &s_fogVolumeBinder,
     &s_materialBinder,
     &s_textureBinder,
-    &s_skeletonBinder
+    &s_skeletonBinder,
+    &s_spriteBinder
 };

--- a/Source/Engine/rendering/shadows/ShadowMapAllocator.cpp
+++ b/Source/Engine/rendering/shadows/ShadowMapAllocator.cpp
@@ -16,6 +16,8 @@
 #include <rendering/Frame.hpp>
 #include <rendering/Texture.hpp>
 
+#include <rendering/CommandRecorder.hpp>
+
 #include <rendering/TextureViewCache.hpp>
 
 #include <rendering/util/DeletionQueue.hpp>
@@ -72,6 +74,7 @@ ShadowMapAllocator::~ShadowMapAllocator()
 {
     EnqueueDeletion(std::move(m_atlasTextureArray));
     EnqueueDeletion(std::move(m_pointLightTextureArray));
+    EnqueueDeletion(std::move(m_clearTexture));
 }
 
 void ShadowMapAllocator::Initialize()
@@ -103,6 +106,29 @@ void ShadowMapAllocator::Initialize()
     
     m_pointLightTextureArray->SetName(NAME("PointLightShadowMapImage"));
     CheckResult(m_pointLightTextureArray->Create());
+
+    m_clearTexture = MakeHandle<Texture>(TextureDesc {
+        TextureType::Texture2DArray,
+        TextureFormat::D16,
+        Vec3u { m_atlasDimensions, 1 },
+        TFM_NEAREST,
+        TFM_NEAREST,
+        TWM_CLAMP_TO_EDGE,
+        1,
+        IU_SAMPLED | IU_ATTACHMENT
+    });
+    m_clearTexture->SetName(NAME("ShadowMapClearTexture"));
+    CheckResult(m_clearTexture->Create());
+
+    { // Clear that clear texture
+        CommandRecorder& cr = g_renderInterface->commandRecorderAllocator.GetCommandRecorder();
+
+        cr << InsertBarrier(m_clearTexture->GetGpuImage(), RS_COPY_DST);
+        cr << FillImage(m_clearTexture->GetGpuImage(), 1.0f, ImageSubResource {});
+        cr << InsertBarrier(m_clearTexture->GetGpuImage(), RS_COPY_SRC);
+
+        cr.Done();
+    }
 }
 
 void ShadowMapAllocator::Shutdown()
@@ -228,6 +254,41 @@ bool ShadowMapAllocator::FreeShadowMap(ShadowMap* shadowMap)
             if (!result)
             {
                 HYP_LOG(Rendering, Error, "Failed to remove shadow map from atlas - not found! (atlas index: {})", atlasElement.layerIndex);
+            }
+            else
+            {
+                Frame* frame = g_renderInterface->GetCurrentFrame();
+                if (frame != nullptr)
+                {
+                    ImageSubResource srcSubResource {};
+                    srcSubResource.baseArrayLayer = 0;
+                    srcSubResource.numLayers = 1;
+                    srcSubResource.baseMipLevel = 0;
+                    srcSubResource.numLevels = 1;
+
+                    ImageSubResource dstSubResource {};
+                    dstSubResource.baseArrayLayer = atlasElement.layerIndex;
+                    dstSubResource.numLayers = 1;
+                    dstSubResource.baseMipLevel = 0;
+                    dstSubResource.numLevels = 1;
+
+                    Vec3u srcOffset = Vec3u(atlasElement.offsetCoords, 0);
+                    Vec3u extent = Vec3u(atlasElement.dimensions, 1);
+
+                    frame->cr << InsertBarrier(
+                        m_atlasTextureArray->GetGpuImage(),
+                        RS_COPY_DST,
+                        dstSubResource);
+
+                    frame->cr << CopyImage(
+                        m_clearTexture->GetGpuImage(),
+                        m_atlasTextureArray->GetGpuImage(),
+                        srcOffset,
+                        Vec3u::Zero(),
+                        extent,
+                        srcSubResource,
+                        dstSubResource);
+                }
             }
         }
     }

--- a/Source/Engine/rendering/shadows/ShadowMapAllocator.hpp
+++ b/Source/Engine/rendering/shadows/ShadowMapAllocator.hpp
@@ -171,6 +171,7 @@ private:
 
     Handle<Texture> m_atlasTextureArray;
     Handle<Texture> m_pointLightTextureArray;
+    Handle<Texture> m_clearTexture;
 
     IdGenerator m_pointLightShadowMapIdGenerator;
 };

--- a/Source/Engine/rendering/util/ShaderCompiler.cpp
+++ b/Source/Engine/rendering/util/ShaderCompiler.cpp
@@ -1682,7 +1682,7 @@ static bool LoadBundleFromAssetPath(const AssetPath& path, Handle<ShaderBundle>&
         return false;
     }
 
-    outBundle = ObjCast<ShaderBundle>(asset);
+    outBundle = DynamicCast<ShaderBundle>(asset);
 
     return true;
 }

--- a/Source/Engine/rendering/util/ShaderCompiler.cpp
+++ b/Source/Engine/rendering/util/ShaderCompiler.cpp
@@ -387,6 +387,40 @@ static String ShaderPropertyValueToString(const ShaderProperty::Value& v)
     return str;
 }
 
+static bool AreShaderPropertyValuesEquivalent(const ShaderProperty::Value& a, const ShaderProperty::Value& b)
+{
+    if (a.Is<int>() && b.Is<int>())
+    {
+        return a.GetUnchecked<int>() == b.GetUnchecked<int>();
+    }
+
+    if (a.Is<float>() && b.Is<float>())
+    {
+        return a.GetUnchecked<float>() == b.GetUnchecked<float>();
+    }
+
+    if (a.Is<int>() && b.Is<float>())
+    {
+        const int intVal = a.GetUnchecked<int>();
+        const float floatVal = b.GetUnchecked<float>();
+        return float(intVal) == floatVal && MathUtil::Fract(floatVal) == 0.0f;
+    }
+
+    if (a.Is<float>() && b.Is<int>())
+    {
+        const float floatVal = a.GetUnchecked<float>();
+        const int intVal = b.GetUnchecked<int>();
+        return floatVal == float(intVal) && MathUtil::Fract(floatVal) == 0.0f;
+    }
+
+    if (a.Is<Name>() && b.Is<Name>())
+    {
+        return a.GetUnchecked<Name>() == b.GetUnchecked<Name>();
+    }
+
+    return false;
+}
+
 void MergeGlobalShaderProperties(ShaderPropertySet& out)
 {
 #if HYP_VULKAN
@@ -1452,7 +1486,7 @@ static bool IsShaderRequestCoveredByPerms(
 
             if (bundleIt->IsStatic())
             {
-                if (bundleIt->currentValue == requested.currentValue)
+                if (AreShaderPropertyValuesEquivalent(bundleIt->currentValue, requested.currentValue))
                 {
                     // match, ok
                     continue;
@@ -1475,7 +1509,7 @@ static bool IsShaderRequestCoveredByPerms(
                 const bool found = bundleIt->enumValues.FindIf(
                                        [&requested](const ShaderProperty::Value& v)
                                        {
-                                           return v == requested.currentValue;
+                                           return AreShaderPropertyValuesEquivalent(v, requested.currentValue);
                                        })
                     != bundleIt->enumValues.End();
 

--- a/Source/Engine/rendering/vulkan/VulkanDescriptorSet.cpp
+++ b/Source/Engine/rendering/vulkan/VulkanDescriptorSet.cpp
@@ -75,7 +75,7 @@ static inline void ValidateDynamicOffset(
         const auto firstValueIt = element->values.Begin();
         if (firstValueIt != element->values.End())
         {
-            VulkanGpuBuffer* buffer = ObjCast<VulkanGpuBuffer>(*firstValueIt);
+            VulkanGpuBuffer* buffer = DynamicCast<VulkanGpuBuffer>(*firstValueIt);
 
             if (buffer != nullptr)
             {
@@ -343,7 +343,7 @@ void VulkanDescriptorSet::UpdateDirtyState(bool* outIsDirty)
             {
                 ObjectBase* ptr = element.values[index];
 
-                VulkanGpuTlas* ref = ObjCast<VulkanGpuTlas>(ptr);
+                VulkanGpuTlas* ref = DynamicCast<VulkanGpuTlas>(ptr);
                 AssertDebug(ref != nullptr, "Invalid TLAS reference for descriptor set element: {}.{}[{}]", m_layout.GetName(), name, index);
                 AssertDebug(ref->GetVulkanHandle() != VK_NULL_HANDLE, "Invalid TLAS for descriptor set element: {}.{}[{}]", m_layout.GetName(), name, index);
 

--- a/Source/Engine/rendering/vulkan/VulkanGpuImage.cpp
+++ b/Source/Engine/rendering/vulkan/VulkanGpuImage.cpp
@@ -976,8 +976,6 @@ void VulkanGpuImage::Blit(
                 ToVkFilter(GetMinFilterMode()));
         }
     }
-
-    return;
 }
 
 void VulkanGpuImage::CopyFromBuffer(
@@ -1143,6 +1141,66 @@ void VulkanGpuImage::CopyToBuffer(
         }
 
         bufferOffset += mipByteSize;
+    }
+}
+
+void VulkanGpuImage::Fill(
+    VulkanCommandBuffer* commandBuffer,
+    float value,
+    const ImageSubResource& subResource,
+    const Vec3u& offset,
+    const Vec3u& extent)
+{
+    const bool isDepthStencil = m_textureDesc.IsDepthStencil();
+
+    VkImageAspectFlags aspectFlagBits = 0;
+
+    if (isDepthStencil)
+    {
+        aspectFlagBits |= VK_IMAGE_ASPECT_DEPTH_BIT;
+
+        if (TextureUtils::HasStencilComponent(m_textureDesc.format))
+        {
+            aspectFlagBits |= VK_IMAGE_ASPECT_STENCIL_BIT;
+        }
+    }
+    else
+    {
+        aspectFlagBits |= VK_IMAGE_ASPECT_COLOR_BIT;
+    }
+
+    VkImageSubresourceRange subresourceRange {};
+    subresourceRange.aspectMask = aspectFlagBits;
+    subresourceRange.baseMipLevel = subResource.baseMipLevel;
+    subresourceRange.levelCount = subResource.numLevels != UINT8_MAX ? subResource.numLevels : 1;
+    subresourceRange.baseArrayLayer = subResource.baseArrayLayer;
+    subresourceRange.layerCount = subResource.numLayers != UINT16_MAX ? subResource.numLayers : 1;
+
+    InsertBarrier(commandBuffer, subResource, RS_COPY_DST, ShaderModuleType::None);
+
+    if (isDepthStencil)
+    {
+        VkClearDepthStencilValue clearValue = { .depth = value, .stencil = 0 };
+
+        vkCmdClearDepthStencilImage(
+            commandBuffer->GetVulkanHandle(),
+            m_handle,
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            &clearValue,
+            1,
+            &subresourceRange);
+    }
+    else
+    {
+        VkClearColorValue clearValue = { .float32 = { value, value, value, value } };
+
+        vkCmdClearColorImage(
+            commandBuffer->GetVulkanHandle(),
+            m_handle,
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            &clearValue,
+            1,
+            &subresourceRange);
     }
 }
 

--- a/Source/Engine/rendering/vulkan/VulkanGpuImage.hpp
+++ b/Source/Engine/rendering/vulkan/VulkanGpuImage.hpp
@@ -93,6 +93,13 @@ public:
         VulkanGpuBuffer* dstBuffer,
         const ImageSubResource& subResource) const override;
 
+    void Fill(
+        VulkanCommandBuffer* commandBuffer,
+        float value,
+        const ImageSubResource& subResource,
+        const Vec3u& offset = Vec3u::Zero(),
+        const Vec3u& extent = Vec3u::One()) override;
+
     void CopyFrom(
         VulkanCommandBuffer* commandBuffer,
         const VulkanGpuImage* srcImage,

--- a/Source/Engine/rendering/vulkan/VulkanRenderInterface.cpp
+++ b/Source/Engine/rendering/vulkan/VulkanRenderInterface.cpp
@@ -1296,7 +1296,7 @@ VkSurfaceKHR VulkanRenderInterface::CreateSurface(ApplicationWindow* window, IDu
     Win32ApplicationWindow* win32Window = nullptr;
     if (window != nullptr)
     {
-        win32Window = ObjCast<Win32ApplicationWindow>(window);
+        win32Window = DynamicCast<Win32ApplicationWindow>(window);
         Assert(win32Window != nullptr);
     }
 
@@ -1305,7 +1305,7 @@ VkSurfaceKHR VulkanRenderInterface::CreateSurface(ApplicationWindow* window, IDu
     CocoaApplicationWindow* cocoaWindow = nullptr;
     if (window != nullptr)
     {
-        cocoaWindow = ObjCast<CocoaApplicationWindow>(window);
+        cocoaWindow = DynamicCast<CocoaApplicationWindow>(window);
         Assert(cocoaWindow != nullptr);
     }
 
@@ -1314,7 +1314,7 @@ VkSurfaceKHR VulkanRenderInterface::CreateSurface(ApplicationWindow* window, IDu
     SDLApplicationWindow* sdlWindow = nullptr;
     if (window != nullptr)
     {
-        sdlWindow = ObjCast<SDLApplicationWindow>(window);
+        sdlWindow = DynamicCast<SDLApplicationWindow>(window);
         Assert(sdlWindow != nullptr);
     }
 
@@ -1325,7 +1325,7 @@ VkSurfaceKHR VulkanRenderInterface::CreateSurface(ApplicationWindow* window, IDu
         window = g_appContext->GetMainWindow();
     }
 
-    AndroidApplicationWindow* androidWindow = ObjCast<AndroidApplicationWindow>(window);
+    AndroidApplicationWindow* androidWindow = DynamicCast<AndroidApplicationWindow>(window);
     Assert(androidWindow != nullptr);
 
     return AndroidAppContext::CreateVulkanSurface(androidWindow, ppOutDummySurfaceContext);
@@ -1338,7 +1338,7 @@ VkSurfaceKHR VulkanRenderInterface::CreateSurface(ApplicationWindow* window, IDu
 RendererResult VulkanRenderInterface::GetVkExtensions(Array<const char*>& outExtensions)
 {
 #if HYP_MACOS
-    if (const CocoaAppContext* cocoaAppContext = ObjCast<CocoaAppContext>(g_appContext))
+    if (const CocoaAppContext* cocoaAppContext = DynamicCast<CocoaAppContext>(g_appContext))
     {
         static constexpr const char* RequiredExtensions[] = {
             VK_KHR_SURFACE_EXTENSION_NAME,
@@ -1379,7 +1379,7 @@ RendererResult VulkanRenderInterface::GetVkExtensions(Array<const char*>& outExt
 #endif
 
 #if HYP_SDL
-    if (const SDLAppContext* sdlAppContext = ObjCast<SDLAppContext>(g_appContext))
+    if (const SDLAppContext* sdlAppContext = DynamicCast<SDLAppContext>(g_appContext))
     {
         uint32 numExtensions = 0;
         SDL_Window* sdlWindow = static_cast<SDL_Window*>(static_cast<SDLApplicationWindow*>(sdlAppContext->GetMainWindow())->GetHWND());
@@ -1443,7 +1443,7 @@ RendererResult VulkanRenderInterface::GetVkExtensions(Array<const char*>& outExt
 #endif
 
 #if HYP_ANDROID
-    if (const AndroidAppContext* androidAppContext = ObjCast<AndroidAppContext>(g_appContext))
+    if (const AndroidAppContext* androidAppContext = DynamicCast<AndroidAppContext>(g_appContext))
     {
         static const char* RequiredExtensions[] = {
             VK_KHR_SURFACE_EXTENSION_NAME,

--- a/Source/Engine/rendering/vulkan/VulkanSwapchain.cpp
+++ b/Source/Engine/rendering/vulkan/VulkanSwapchain.cpp
@@ -57,7 +57,7 @@ static RendererResult AcquireNextImage(
         VK_NULL_HANDLE,
         index);
 
-    if (pOutNeedsRecreate != nullptr && (vkResult == VK_ERROR_OUT_OF_DATE_KHR || vkResult == VK_SUBOPTIMAL_KHR))
+    if (pOutNeedsRecreate != nullptr && vkResult == VK_ERROR_OUT_OF_DATE_KHR)
     {
         *pOutNeedsRecreate = true;
     }
@@ -161,7 +161,7 @@ void VulkanSwapchain::PresentFrame(VulkanFrame* frame, VulkanDeviceQueue* queue)
 
     VkResult result = vkQueuePresentKHR(queue->queue, &presentInfo);
 
-    if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR)
+    if (result == VK_ERROR_OUT_OF_DATE_KHR)
     {
         HYP_LOG(RenderingBackend, Verbose, "Got out of date swapchain present result ({}), calling Recreate()", result);
 

--- a/Source/Engine/rendering/vulkan/VulkanTextureViewCache.cpp
+++ b/Source/Engine/rendering/vulkan/VulkanTextureViewCache.cpp
@@ -25,15 +25,33 @@ static uint64 CalculateImageViewHash(const ImageSubResource& subResource, Textur
         .Value();
 }
 
+VulkanTextureViewCache::VulkanTextureViewCache()
+{
+    const size_t numSubtypes = GetNumDescendants(TypeId::ForType<Texture>()) + 1;
+    subtypeImpls.Resize(numSubtypes);
+}
+
 VulkanTextureViewCache::~VulkanTextureViewCache()
 {
-    for (auto& it : imageViews)
+    for (auto& subtype : subtypeImpls)
     {
-        for (auto& jt : it)
+        for (auto& it : subtype.imageViews)
         {
-            jt.second.Reset();
+            for (auto& jt : it)
+            {
+                jt.second.Reset();
+            }
         }
     }
+}
+
+VulkanTextureViewCache::SubtypeData& VulkanTextureViewCache::GetSubtypeData(ObjId<Texture> id)
+{
+    const int classIndex = GetSubclassIndex(TypeId::ForType<Texture>(), id.GetTypeId()) + 1;
+    AssertDebug(classIndex >= 0, "Invalid class index {}", classIndex);
+    AssertDebug(classIndex < int(subtypeImpls.Size()), "Invalid class index {}", classIndex);
+
+    return subtypeImpls[classIndex];
 }
 
 const VulkanGpuImageViewRef& VulkanTextureViewCache::GetOrCreate(
@@ -90,13 +108,15 @@ const VulkanGpuImageViewRef& VulkanTextureViewCache::GetOrCreate(
 
     TSharedLock sharedLock(mutex);
 
-    if (!imageViews.HasIndex(idx))
+    SubtypeData& subtypeData = GetSubtypeData(texture->Id());
+
+    if (!subtypeData.imageViews.HasIndex(idx))
     {
-        imageViews.Emplace(idx);
-        weakTextureHandles.Emplace(idx, MakeWeakRef(texture));
+        subtypeData.imageViews.Emplace(idx);
+        subtypeData.weakTextureHandles.Emplace(idx, MakeWeakRef(texture));
     }
 
-    auto& textureImageViews = imageViews.Get(idx);
+    auto& textureImageViews = subtypeData.imageViews.Get(idx);
 
     ValueStorage<TUniqueLock<SharedMutex>> uniqueLockStorage {};
     bool isLockUnique = false;
@@ -142,15 +162,17 @@ void VulkanTextureViewCache::RemoveTexture(const Texture* texture)
 
     TUniqueLock lock(mutex);
 
-    if (imageViews.HasIndex(idx))
+    SubtypeData& subtypeData = GetSubtypeData(texture->Id());
+
+    if (subtypeData.imageViews.HasIndex(idx))
     {
-        for (auto& it : imageViews.Get(idx))
+        for (auto& it : subtypeData.imageViews.Get(idx))
         {
-            it.second.Reset();
+            EnqueueDeletion(std::move(it.second));
         }
 
-        imageViews.EraseAt(idx);
-        weakTextureHandles.EraseAt(idx);
+        subtypeData.imageViews.EraseAt(idx);
+        subtypeData.weakTextureHandles.EraseAt(idx);
     }
 }
 
@@ -162,50 +184,46 @@ void VulkanTextureViewCache::CleanupUnusedTextures()
 
     constexpr uint32 MaxCycles = 32;
 
-    cleanupIterator = typename decltype(weakTextureHandles)::Iterator {
-        &weakTextureHandles,
-        cleanupIterator.page,
-        cleanupIterator.elem
-    };
-
-    if (cleanupIterator == weakTextureHandles.End())
-    {
-        cleanupIterator = weakTextureHandles.Begin();
-    }
-
     uint32 numRemoved = 0;
 
-    for (uint32 i = 0; cleanupIterator != weakTextureHandles.End() && i < MaxCycles; i++)
+    for (auto& subtype : subtypeImpls)
     {
-        auto& entry = *cleanupIterator;
+        auto it = subtype.weakTextureHandles.Begin();
 
-        if (entry.Expired())
+        for (uint32 i = 0; it != subtype.weakTextureHandles.End() && numRemoved < MaxCycles; i++)
         {
-            const size_t idx = weakTextureHandles.IndexOf(cleanupIterator);
-
-            Assert(imageViews.HasIndex(idx));
-            Assert(weakTextureHandles.HasIndex(idx));
-
-            for (auto& it : imageViews.Get(idx))
+            if (it->Expired())
             {
-                EnqueueDeletion(std::move(it.second));
+                const size_t idx = subtype.weakTextureHandles.IndexOf(it);
+
+                Assert(subtype.imageViews.HasIndex(idx));
+
+                for (auto& jt : subtype.imageViews.Get(idx))
+                {
+                    EnqueueDeletion(std::move(jt.second));
+                }
+
+                subtype.imageViews.EraseAt(idx);
+
+                it = subtype.weakTextureHandles.Erase(it);
+
+                ++numRemoved;
+
+                continue;
             }
 
-            imageViews.EraseAt(idx);
-
-            cleanupIterator = weakTextureHandles.Erase(cleanupIterator);
-
-            ++numRemoved;
-
-            continue;
+            ++it;
         }
 
-        ++cleanupIterator;
+        if (numRemoved >= MaxCycles)
+        {
+            break;
+        }
     }
 
     if (numRemoved != 0)
     {
-        HYP_LOG(RenderingBackend, Verbose, "VulkanTextureCache: Cleaned up {} unused textures", numRemoved);
+        HYP_LOG(RenderingBackend, Verbose, "VulkanTextureViewCache: Cleaned up {} unused textures", numRemoved);
     }
 }
 

--- a/Source/Engine/rendering/vulkan/VulkanTextureViewCache.hpp
+++ b/Source/Engine/rendering/vulkan/VulkanTextureViewCache.hpp
@@ -26,18 +26,16 @@ class VulkanTextureViewCache final : public TextureViewCacheBase
 public:
     using TextureImageViewMap = HashMap<uint64, VulkanGpuImageViewRef, VulkanAllocator>;
 
-    SharedMutex mutex;
-    // map texture ID -> image views
-    SparsePagedArray<TextureImageViewMap, 32, VulkanAllocator> imageViews;
-    // to keep texture IDs as valid
-    SparsePagedArray<WeakHandle<Texture>, 32, VulkanAllocator> weakTextureHandles;
-
-    typename decltype(weakTextureHandles)::Iterator cleanupIterator;
-
-    VulkanTextureViewCache()
+    struct SubtypeData
     {
-        cleanupIterator = weakTextureHandles.End();
-    }
+        SparsePagedArray<TextureImageViewMap, 32, VulkanAllocator> imageViews;
+        SparsePagedArray<WeakHandle<Texture>, 32, VulkanAllocator> weakTextureHandles;
+    };
+
+    SharedMutex mutex;
+    Array<SubtypeData, VulkanAllocator> subtypeImpls;
+
+    VulkanTextureViewCache();
 
     ~VulkanTextureViewCache() override;
 
@@ -59,6 +57,9 @@ public:
 
     void RemoveTexture(const Texture* texture) override;
     void CleanupUnusedTextures() override;
+
+private:
+    SubtypeData& GetSubtypeData(ObjId<Texture> id);
 };
 
 } // namespace Hyperion

--- a/Source/Engine/scene/Entity.cpp
+++ b/Source/Engine/scene/Entity.cpp
@@ -295,14 +295,12 @@ void Entity::OnComponentAdded(AnyRef component)
             return;
         }
 
-        if (m_entityInitInfo.bvhDepth > 0)
+        AddTag<EntityTag::UpdateRenderProxy>();
+        
+        // build mesh BVH if there is no existing one. (size != 0)
+        if (m_entityInitInfo.bvhDepth > 0
+            && meshComponent->mesh->GetBVHDataReference().size == 0)
         {
-            if (meshComponent->mesh->GetBVH().IsValid())
-            {
-                // already has a BVH, skip
-                return;
-            }
-
             if (!meshComponent->mesh->BuildBVH(m_entityInitInfo.bvhDepth))
             {
                 HYP_LOG(Entity, Error, "Failed to build BVH for MeshComponent on Entity {}!", Id());
@@ -310,8 +308,6 @@ void Entity::OnComponentAdded(AnyRef component)
                 return;
             }
         }
-
-        AddTag<EntityTag::UpdateRenderProxy>();
 
         return;
     }

--- a/Source/Engine/scene/Entity.hpp
+++ b/Source/Engine/scene/Entity.hpp
@@ -42,8 +42,6 @@ class HYP_API Entity : public Node
 {
     HYP_OBJECT_BODY(Entity);
 
-    friend class EntityRenderProxySystem_Mesh;
-
 public:
     friend class EntityManager;
     friend class Node;

--- a/Source/Engine/scene/InstancedMeshProxy.cpp
+++ b/Source/Engine/scene/InstancedMeshProxy.cpp
@@ -29,7 +29,7 @@ void InstancedMeshProxy::OnAttachedToNode(Node* node)
     Node::OnAttachedToNode(node);
 
     // If we are being attached to an entity, we want to make sure the new parent entity has the UpdateInstancedMeshData tag
-    if (Entity* entity = ObjCast<Entity>(node))
+    if (Entity* entity = DynamicCast<Entity>(node))
     {
         entity->AddTag<EntityTag::UpdateInstancedMeshData>();
     }
@@ -39,7 +39,7 @@ void InstancedMeshProxy::OnDetachedFromNode(Node* node)
 {
     Node::OnDetachedFromNode(node);
 
-    if (Entity* entity = ObjCast<Entity>(node))
+    if (Entity* entity = DynamicCast<Entity>(node))
     {
         entity->AddTag<EntityTag::UpdateInstancedMeshData>();
     }
@@ -49,7 +49,7 @@ void InstancedMeshProxy::OnTransformUpdated()
 {
     Node::OnTransformUpdated();
 
-    if (Entity* entity = ObjCast<Entity>(GetParent()))
+    if (Entity* entity = DynamicCast<Entity>(GetParent()))
     {
         entity->AddTag<EntityTag::UpdateInstancedMeshData>();
     }

--- a/Source/Engine/scene/Node.cpp
+++ b/Source/Engine/scene/Node.cpp
@@ -1030,10 +1030,7 @@ bool Node::TestRay(const Ray& ray, RayTestResults& outResults, EnumFlags<RayTest
                     }
                 }
 
-                if (TransformComponent* transformComponent = entity->TryGetComponent<TransformComponent>())
-                {
-                    modelMatrix = entity->GetWorldMatrix();
-                }
+                modelMatrix = entity->GetWorldMatrix();
             }
 
             if (bvh)

--- a/Source/Engine/scene/Sprite.cpp
+++ b/Source/Engine/scene/Sprite.cpp
@@ -1,0 +1,117 @@
+/*!
+ *  @author: The Hyperion Contributors
+ *  @date 2016-2026
+ *  @licence MIT
+ */
+
+#include <ScenePch.hpp>
+
+#include <scene/Sprite.hpp>
+#include <scene/Scene.hpp>
+#include <scene/EnvProbe.hpp>
+#include <scene/LightmapVolume.hpp>
+#include <scene/camera/Camera.hpp>
+
+#include <rendering/RenderProxy.hpp>
+#include <rendering/Texture.hpp>
+
+#include <Sprite.generated.inl>
+
+namespace Hyperion {
+
+Sprite::Sprite()
+    : Sprite(SpriteType::None)
+{
+}
+
+Sprite::Sprite(SpriteType spriteType)
+    : Entity(NAME("Sprite"))
+{
+    spriteType = spriteType;
+}
+
+Sprite::~Sprite() = default;
+
+void Sprite::Init()
+{
+    Entity::Init();
+}
+
+void Sprite::UpdateRenderProxy(RenderProxySprite* proxy)
+{
+    proxy->sprite = WeakHandleFromThis();
+    proxy->texture = texture.Get();
+
+    SpriteShaderData& bufferData = proxy->bufferData;
+    bufferData.positionSize = Vec4f(GetWorldTranslation(), size);
+    bufferData.color = Vec4f(color);
+    bufferData.spriteType = uint32(spriteType);
+    bufferData.opacity = opacity;
+    bufferData.alwaysFaceCamera = alwaysFaceCamera ? 1u : 0u;
+    bufferData.textureIndex = ~0u;
+}
+
+Handle<Sprite> Sprite::CreateEnvProbeSprite(Scene* scene, EnvProbe* envProbe)
+{
+    Handle<Sprite> sprite = MakeHandle<Sprite>(SpriteType::EnvProbe);
+    InitObject(sprite);
+
+    sprite->size = 2.0f;
+    sprite->color = Color::Cyan();
+    sprite->opacity = 0.5f;
+    sprite->alwaysFaceCamera = true;
+    sprite->m_envProbe = MakeStrongRef(envProbe);
+
+    if (envProbe)
+    {
+        sprite->SetWorldTranslation(envProbe->GetWorldBounds().GetCenter());
+    }
+
+    scene->GetRoot()->AddChild(sprite);
+
+    return sprite;
+}
+
+Handle<Sprite> Sprite::CreateLightmapVolumeSprite(Scene* scene, LightmapVolume* lightmapVolume)
+{
+    Handle<Sprite> sprite = MakeHandle<Sprite>(SpriteType::LightmapVolume);
+    InitObject(sprite);
+
+    sprite->size = 2.0f;
+    sprite->color = Color::Magenta();
+    sprite->opacity = 0.5f;
+    sprite->alwaysFaceCamera = true;
+    sprite->m_lightmapVolume = MakeStrongRef(lightmapVolume);
+
+    if (lightmapVolume)
+    {
+        sprite->SetWorldTranslation(lightmapVolume->GetWorldBounds().GetCenter());
+    }
+
+    scene->GetRoot()->AddChild(sprite);
+
+    return sprite;
+}
+
+Handle<Sprite> Sprite::CreateCameraSprite(Scene* scene, Camera* camera)
+{
+    Handle<Sprite> sprite = MakeHandle<Sprite>(SpriteType::Camera);
+    InitObject(sprite);
+
+    sprite->size = 1.5f;
+    sprite->color = Color::Yellow();
+    sprite->opacity = 0.5f;
+    sprite->alwaysFaceCamera = true;
+    sprite->m_camera = MakeStrongRef(camera);
+
+    if (camera)
+    {
+        sprite->SetWorldTranslation(camera->GetWorldTranslation());
+    }
+
+    scene->GetRoot()->AddChild(sprite);
+
+    return sprite;
+}
+
+} // namespace Hyperion

--- a/Source/Engine/scene/Sprite.cpp
+++ b/Source/Engine/scene/Sprite.cpp
@@ -20,14 +20,14 @@
 namespace Hyperion {
 
 Sprite::Sprite()
-    : Sprite(SpriteType::None)
+    : Sprite(Name::Invalid(), SpriteType::None)
 {
 }
 
-Sprite::Sprite(SpriteType spriteType)
-    : Entity(NAME("Sprite"))
+Sprite::Sprite(Name name, SpriteType spriteType)
+    : Entity(name),
+      spriteType(spriteType)
 {
-    spriteType = spriteType;
 }
 
 Sprite::~Sprite() = default;
@@ -53,7 +53,7 @@ void Sprite::UpdateRenderProxy(RenderProxySprite* proxy)
 
 Handle<Sprite> Sprite::CreateEnvProbeSprite(Scene* scene, EnvProbe* envProbe)
 {
-    Handle<Sprite> sprite = MakeHandle<Sprite>(SpriteType::EnvProbe);
+    Handle<Sprite> sprite = MakeHandle<Sprite>(NAME_FMT("{}_Sprite", envProbe->GetName()), SpriteType::EnvProbe);
     InitObject(sprite);
 
     sprite->size = 2.0f;
@@ -74,7 +74,7 @@ Handle<Sprite> Sprite::CreateEnvProbeSprite(Scene* scene, EnvProbe* envProbe)
 
 Handle<Sprite> Sprite::CreateLightmapVolumeSprite(Scene* scene, LightmapVolume* lightmapVolume)
 {
-    Handle<Sprite> sprite = MakeHandle<Sprite>(SpriteType::LightmapVolume);
+    Handle<Sprite> sprite = MakeHandle<Sprite>(NAME_FMT("{}_Sprite", lightmapVolume->GetName()), SpriteType::LightmapVolume);
     InitObject(sprite);
 
     sprite->size = 2.0f;
@@ -95,7 +95,7 @@ Handle<Sprite> Sprite::CreateLightmapVolumeSprite(Scene* scene, LightmapVolume* 
 
 Handle<Sprite> Sprite::CreateCameraSprite(Scene* scene, Camera* camera)
 {
-    Handle<Sprite> sprite = MakeHandle<Sprite>(SpriteType::Camera);
+    Handle<Sprite> sprite = MakeHandle<Sprite>(NAME_FMT("{}_Sprite", camera->GetName()), SpriteType::Camera);
     InitObject(sprite);
 
     sprite->size = 1.5f;

--- a/Source/Engine/scene/Sprite.hpp
+++ b/Source/Engine/scene/Sprite.hpp
@@ -1,0 +1,74 @@
+/*!
+ *  @author: The Hyperion Contributors
+ *  @date 2016-2026
+ *  @licence MIT
+ */
+
+#pragma once
+
+#include <Core/Types.hpp>
+
+#include <Core/math/Color.hpp>
+
+#include <scene/Entity.hpp>
+
+namespace Hyperion {
+
+class Texture;
+class Scene;
+class EnvProbe;
+class LightmapVolume;
+class Camera;
+
+HYP_ENUM()
+enum class SpriteType : uint32
+{
+    None = 0,
+
+    Point2D,
+    Spot3D,
+    Crosshair,
+
+    EnvProbe,
+    LightmapVolume,
+    Camera,
+
+    Max
+};
+
+HYP_CLASS(AssetBucket = "Sprites")
+class HYP_API Sprite : public Entity
+{
+    HYP_OBJECT_BODY(Sprite);
+
+public:
+    Sprite();
+    explicit Sprite(SpriteType spriteType);
+
+    Sprite(const Sprite& other) = delete;
+    Sprite& operator=(const Sprite& other) = delete;
+
+    ~Sprite() override;
+
+    void UpdateRenderProxy(class RenderProxySprite* proxy);
+
+    static Handle<Sprite> CreateEnvProbeSprite(Scene* scene, EnvProbe* envProbe);
+    static Handle<Sprite> CreateLightmapVolumeSprite(Scene* scene, LightmapVolume* lightmapVolume);
+    static Handle<Sprite> CreateCameraSprite(Scene* scene, Camera* camera);
+
+    SpriteType spriteType = SpriteType::None;
+    float size = 1.0f;
+    Color color = Color::White();
+    Handle<Texture> texture;
+    float opacity = 1.0f;
+    bool alwaysFaceCamera = true;
+
+    Handle<EnvProbe> m_envProbe;
+    Handle<LightmapVolume> m_lightmapVolume;
+    Handle<Camera> m_camera;
+
+protected:
+    void Init() override;
+};
+
+} // namespace Hyperion

--- a/Source/Engine/scene/Sprite.hpp
+++ b/Source/Engine/scene/Sprite.hpp
@@ -43,7 +43,7 @@ class HYP_API Sprite : public Entity
 
 public:
     Sprite();
-    explicit Sprite(SpriteType spriteType);
+    Sprite(Name name, SpriteType spriteType);
 
     Sprite(const Sprite& other) = delete;
     Sprite& operator=(const Sprite& other) = delete;

--- a/Source/Engine/scene/Sprite.hpp
+++ b/Source/Engine/scene/Sprite.hpp
@@ -32,6 +32,7 @@ enum class SpriteType : uint32
     EnvProbe,
     LightmapVolume,
     Camera,
+    Text,
 
     Max
 };
@@ -50,7 +51,7 @@ public:
 
     ~Sprite() override;
 
-    void UpdateRenderProxy(class RenderProxySprite* proxy);
+    virtual void UpdateRenderProxy(class RenderProxySprite* proxy);
 
     static Handle<Sprite> CreateEnvProbeSprite(Scene* scene, EnvProbe* envProbe);
     static Handle<Sprite> CreateLightmapVolumeSprite(Scene* scene, LightmapVolume* lightmapVolume);
@@ -63,6 +64,7 @@ public:
     float opacity = 1.0f;
     bool alwaysFaceCamera = true;
 
+    // @TODO Move to EditorSprite class? Use Handle<ObjectBase> to reduce memory usage
     Handle<EnvProbe> m_envProbe;
     Handle<LightmapVolume> m_lightmapVolume;
     Handle<Camera> m_camera;

--- a/Source/Engine/scene/SystemExecutionGroup.hpp
+++ b/Source/Engine/scene/SystemExecutionGroup.hpp
@@ -128,7 +128,7 @@ public:
             return nullptr;
         }
 
-        return ObjCast<SystemType>(it->second);
+        return DynamicCast<SystemType>(it->second);
     }
 
     /*! \brief Removes a System from the SystemExecutionGroup.

--- a/Source/Engine/scene/TextSprite.cpp
+++ b/Source/Engine/scene/TextSprite.cpp
@@ -172,14 +172,55 @@ static BoundingBox CalculateTextAABB(const FontAtlas& fontAtlas, const String& t
 
     BoundingBox aabb = BoundingBox::Zero();
 
-    ForEachCharacter(fontAtlas, text, textSize, [textSize, &aabb](const FontAtlasCharacterIterator& iter)
+    Vec2f totalSize = Vec2f::Zero();
+    Vec2f placement = Vec2f::Zero();
+    const Vec2f cellDimensions = Vec2f(fontAtlas.GetCellDimensions()) / 64.0f;
+
+    const size_t length = text.Length();
+    for (size_t i = 0; i < length; i++)
+    {
+        const utf::Char32 ch = text.GetChar(i);
+
+        if (ch == utf::Char32(' '))
+        {
+            placement.x += cellDimensions.x * 0.5f;
+            continue;
+        }
+
+        if (ch == utf::Char32('\n'))
+        {
+            totalSize.x = MathUtil::Max(totalSize.x, placement.x);
+            placement.x = 0.0f;
+            placement.y += cellDimensions.y;
+            continue;
+        }
+
+        Optional<const GlyphMetrics&> glyphMetrics = fontAtlas.GetGlyphMetricsForChar(ch);
+        if (!glyphMetrics.HasValue() || (glyphMetrics->width == 0 || glyphMetrics->height == 0))
+        {
+            continue;
+        }
+
+        const Vec2f glyphDimensions = Vec2f(float(glyphMetrics->width), float(glyphMetrics->height)) / 64.0f;
+        const float charWidth = float(glyphMetrics->advance / 64) / 64.0f;
+        const float bearingY = float(glyphMetrics->height - glyphMetrics->bearingY) / 64.0f;
+
+        const float charHeight = glyphDimensions.y + bearingY;
+        totalSize.y = MathUtil::Max(totalSize.y, placement.y + charHeight);
+
+        placement.x += charWidth;
+    }
+
+    totalSize.x = MathUtil::Max(totalSize.x, placement.x);
+
+    ForEachCharacter(fontAtlas, text, textSize, [textSize, &aabb, &totalSize](const FontAtlasCharacterIterator& iter)
         {
             BoundingBox characterAabb = BoundingBox::Zero();
 
-            const float offsetY = (iter.cellDimensions.y - iter.glyphDimensions.y) + iter.bearingY;
+            const float offsetY = -iter.bearingY;
 
-            characterAabb = characterAabb.Union(Vec3f(iter.placement.x, iter.placement.y + offsetY, 0.0f));
-            characterAabb = characterAabb.Union(Vec3f(iter.placement.x + iter.glyphDimensions.x, iter.placement.y + offsetY + iter.cellDimensions.y, 0.0f));
+            characterAabb = characterAabb.Union(Vec3f(iter.placement.x - totalSize.x * 0.5f, iter.placement.y + offsetY - totalSize.y * 0.5f, 0.0f));
+            characterAabb = characterAabb.Union(Vec3f(iter.placement.x + iter.glyphDimensions.x - totalSize.x * 0.5f, iter.placement.y + offsetY + iter.glyphDimensions.y - totalSize.y * 0.5f, 0.0f));
 
             aabb = aabb.Union(characterAabb);
         });

--- a/Source/Engine/scene/TextSprite.cpp
+++ b/Source/Engine/scene/TextSprite.cpp
@@ -291,8 +291,6 @@ void TextSprite::UpdateRenderProxy(RenderProxySprite* proxy)
     proxy->textAabb = m_textAabb;
     proxy->fontAtlas = m_fontAtlas.Get();
     proxy->texture = m_currentFontAtlasTexture.Get();
-
-    proxy->bufferData.positionSize = Vec4f(GetWorldTranslation(), m_textSize);
 }
 
 void TextSprite::UpdateTextAABB()

--- a/Source/Engine/scene/TextSprite.cpp
+++ b/Source/Engine/scene/TextSprite.cpp
@@ -291,6 +291,8 @@ void TextSprite::UpdateRenderProxy(RenderProxySprite* proxy)
     proxy->textAabb = m_textAabb;
     proxy->fontAtlas = m_fontAtlas.Get();
     proxy->texture = m_currentFontAtlasTexture.Get();
+
+    proxy->bufferData.positionSize = Vec4f(GetWorldTranslation(), m_textSize);
 }
 
 void TextSprite::UpdateTextAABB()

--- a/Source/Engine/scene/TextSprite.cpp
+++ b/Source/Engine/scene/TextSprite.cpp
@@ -1,0 +1,308 @@
+/*!
+ *  @author: The Hyperion Contributors
+ *  @date 2016-2026
+ *  @licence MIT
+ */
+
+#include <ScenePch.hpp>
+
+#include <scene/TextSprite.hpp>
+
+#include <scene/EntityManager.hpp>
+#include <scene/components/BoundingBoxComponent.hpp>
+
+#include <ui/font/FontAtlas.hpp>
+
+#include <Core/utilities/GlobalContext.hpp>
+
+#include <asset/AssetRegistry.hpp>
+#include <asset/Assets.hpp>
+
+#include <rendering/RenderProxy.hpp>
+#include <rendering/Texture.hpp>
+
+#include <system/AppContext.hpp>
+
+#include <engine/EngineDriver.hpp>
+
+#include <TextSprite.generated.inl>
+
+namespace Hyperion {
+
+struct FontAtlasCharacterIterator
+{
+    Vec2f placement;
+    Vec2f atlasPixelSize;
+    Vec2f cellDimensions;
+
+    Vec2i charOffset;
+
+    Vec2f glyphDimensions;
+
+    float bearingY;
+    float charWidth;
+};
+
+static TResult<Handle<FontAtlas>> CreateFontAtlas()
+{
+    // we check if it exists in the registry before creating.
+    // some platforms build without freetype support so the atlas must already exist in the registry.
+
+    AssetRegistry& registry = *GetEngineAssetRegistry();
+    
+    GlobalContextScope contextScope { AssetRegistryContext { MakeStrongRef(&registry) } };
+
+    Handle<FontAtlas> fontAtlas = DynamicCast<FontAtlas>(registry.GetAsset(AssetBuckets::FontAtlases, "Roboto_Regular"_sh));
+
+    if (fontAtlas.IsValid())
+    {
+        return fontAtlas;
+    }
+
+    auto fontFaceAsset = g_assetManager->Load<RC<FontFace>>("Fonts/Roboto/Roboto-Regular.ttf");
+
+    if (fontFaceAsset.HasError())
+    {
+        return HYP_MAKE_ERROR(Error, "Failed to load font face! Error: {}", fontFaceAsset.GetError().GetMessage());
+    }
+
+    // create new font atlas
+    fontAtlas = MakeHandle<FontAtlas>(NAME("Roboto_Regular"), std::move(fontFaceAsset->Result()));
+    
+    // render atlas textures.
+    if (Result renderAtlasResult = fontAtlas->RenderAtlasTextures(1.0f, 2.0f, 0.1f); renderAtlasResult.HasError())
+    {
+        return renderAtlasResult.GetError();
+    }
+    
+    registry.PutAssetsDeep(fontAtlas);
+    registry.SaveDirtyAssets();
+
+    // need to move in return since return type is wrapped result
+    return fontAtlas;
+}
+
+template <class Callback>
+static void ForEachCharacter(
+    const FontAtlas& fontAtlas,
+    const String& text,
+    float textSize,
+    Callback&& callback)
+{
+    HYP_SCOPE;
+
+    Vec2f placement = Vec2f::Zero();
+
+    const size_t length = text.Length();
+
+    const Vec2f cellDimensions = Vec2f(fontAtlas.GetCellDimensions()) / 64.0f;
+
+    const Handle<Texture>& mainTextureAtlas = fontAtlas.GetAtlasTextures().GetMainAtlas();
+    AssertDebug(mainTextureAtlas.IsValid(), "Main texture atlas is invalid");
+
+    if (!mainTextureAtlas.IsValid())
+    {
+        return;
+    }
+
+    Vec2f atlasPixelSize;
+
+    if (mainTextureAtlas->GetExtent().Volume() != 0)
+    {
+        atlasPixelSize = Vec2f::One() / Vec2f(mainTextureAtlas->GetExtent().GetXY());
+    }
+
+    Array<FontAtlasCharacterIterator> currentWordChars;
+
+    const auto iterateCurrentWord = [&currentWordChars, &callback]()
+    {
+        for (const FontAtlasCharacterIterator& characterIterator : currentWordChars)
+        {
+            callback(characterIterator);
+        }
+
+        currentWordChars.Clear();
+    };
+
+    for (size_t i = 0; i < length; i++)
+    {
+        const utf::Char32 ch = text.GetChar(i);
+
+        if (ch == utf::Char32(' '))
+        {
+            placement.x += cellDimensions.x * 0.5f;
+            iterateCurrentWord();
+            continue;
+        }
+
+        if (ch == utf::Char32('\n'))
+        {
+            placement.x = 0.0f;
+            placement.y += cellDimensions.y;
+            iterateCurrentWord();
+            continue;
+        }
+
+        Optional<const GlyphMetrics&> glyphMetrics = fontAtlas.GetGlyphMetricsForChar(ch);
+
+        if (!glyphMetrics.HasValue() || (glyphMetrics->width == 0 || glyphMetrics->height == 0))
+        {
+            HYP_LOG_ONCE(Scene, Warning, "Ensure how to render char: {}", (int)ch);
+            continue;
+        }
+
+        FontAtlasCharacterIterator& characterIterator = currentWordChars.EmplaceBack();
+        characterIterator.placement = placement;
+        characterIterator.atlasPixelSize = atlasPixelSize;
+        characterIterator.cellDimensions = cellDimensions;
+        characterIterator.charOffset = glyphMetrics->imagePosition;
+        characterIterator.glyphDimensions = Vec2f(float(glyphMetrics->width), float(glyphMetrics->height)) / 64.0f;
+        characterIterator.bearingY = float(glyphMetrics->height - glyphMetrics->bearingY) / 64.0f;
+        characterIterator.charWidth = float(glyphMetrics->advance / 64) / 64.0f;
+
+        placement.x += characterIterator.charWidth;
+    }
+
+    iterateCurrentWord();
+}
+
+static BoundingBox CalculateTextAABB(const FontAtlas& fontAtlas, const String& text, float textSize)
+{
+    HYP_SCOPE;
+
+    BoundingBox aabb = BoundingBox::Zero();
+
+    ForEachCharacter(fontAtlas, text, textSize, [textSize, &aabb](const FontAtlasCharacterIterator& iter)
+        {
+            BoundingBox characterAabb = BoundingBox::Zero();
+
+            const float offsetY = (iter.cellDimensions.y - iter.glyphDimensions.y) + iter.bearingY;
+
+            characterAabb = characterAabb.Union(Vec3f(iter.placement.x, iter.placement.y + offsetY, 0.0f));
+            characterAabb = characterAabb.Union(Vec3f(iter.placement.x + iter.glyphDimensions.x, iter.placement.y + offsetY + iter.cellDimensions.y, 0.0f));
+
+            aabb = aabb.Union(characterAabb);
+        });
+
+    return aabb * Vec3f(textSize, textSize, 1.0f);
+}
+
+TextSprite::TextSprite()
+    : Sprite(Name::Invalid(), SpriteType::Text)
+{
+}
+
+TextSprite::TextSprite(Name name, const String& text)
+    : Sprite(name, SpriteType::Text),
+      m_text(text)
+{
+    auto result = CreateFontAtlas();
+    if (result.HasValue())
+    {
+        m_fontAtlas = result.GetValue();
+    }
+    else if (result.HasError())
+    {
+        HYP_LOG(Scene, Error, "Failed to set FontAtlas for TextSprite {}: {}", GetName(), result.GetError().GetMessage());
+    }
+}
+
+TextSprite::~TextSprite()
+{
+}
+
+void TextSprite::Init()
+{
+    HYP_SCOPE;
+
+    Sprite::Init();
+
+    auto& bem = GetComponent<BoundingBoxComponent>();
+    bem.worldAabb = m_textAabb;
+}
+
+void TextSprite::SetText(const String& text)
+{
+    m_text = text;
+    UpdateTextAABB();
+
+    auto& bem = GetComponent<BoundingBoxComponent>();
+    bem.worldAabb = m_textAabb;
+
+    SetNeedsRenderProxyUpdate();
+}
+
+void TextSprite::SetTextColor(Color color)
+{
+    m_textColor = color;
+    SetNeedsRenderProxyUpdate();
+}
+
+void TextSprite::SetTextSize(float textSize)
+{
+    m_textSize = textSize;
+    UpdateTextAABB();
+
+    auto& bem = GetComponent<BoundingBoxComponent>();
+    bem.worldAabb = m_textAabb;
+
+    SetNeedsRenderProxyUpdate();
+}
+
+void TextSprite::SetFontAtlas(const Handle<FontAtlas>& fontAtlas)
+{
+    m_fontAtlas = fontAtlas;
+    UpdateTextAABB();
+
+    auto& bem = GetComponent<BoundingBoxComponent>();
+    bem.worldAabb = m_textAabb;
+
+    SetNeedsRenderProxyUpdate();
+}
+
+const Handle<FontAtlas>& TextSprite::GetFontAtlasOrDefault() const
+{
+    return m_fontAtlas;
+}
+
+void TextSprite::UpdateRenderProxy(RenderProxySprite* proxy)
+{
+    Sprite::UpdateRenderProxy(proxy);
+
+    proxy->text = m_text;
+    proxy->textColor = m_textColor;
+    proxy->textSize = m_textSize;
+    proxy->textAabb = m_textAabb;
+
+    if (const Handle<FontAtlas>& fontAtlas = GetFontAtlasOrDefault())
+    {
+        proxy->fontAtlas = fontAtlas.Get();
+        proxy->texture = fontAtlas->GetAtlasTextures().GetAtlasForPixelSize(m_textSize);
+    }
+    else
+    {
+        proxy->fontAtlas = nullptr;
+        proxy->texture = nullptr;
+    }
+}
+
+void TextSprite::UpdateTextAABB()
+{
+    if (const Handle<FontAtlas>& fontAtlas = GetFontAtlasOrDefault())
+    {
+        if (!m_text.Empty())
+        {
+            m_textAabb = CalculateTextAABB(*fontAtlas, m_text, m_textSize);
+        }
+        else
+        {
+            m_textAabb = BoundingBox::Zero();
+        }
+    }
+    else
+    {
+        HYP_LOG(Scene, Verbose, "No font atlas set for TextSprite {}", GetName());
+    }
+}
+
+} // namespace Hyperion

--- a/Source/Engine/scene/TextSprite.cpp
+++ b/Source/Engine/scene/TextSprite.cpp
@@ -219,12 +219,27 @@ void TextSprite::Init()
 
     auto& bem = GetComponent<BoundingBoxComponent>();
     bem.worldAabb = m_textAabb;
+
+    UpdateFontAtlasTexture();
+}
+
+void TextSprite::UpdateFontAtlasTexture()
+{
+    if (const Handle<FontAtlas>& fontAtlas = GetFontAtlasOrDefault())
+    {
+        m_currentFontAtlasTexture = fontAtlas->GetAtlasTextures().GetAtlasForPixelSize(m_textSize);
+    }
+    else
+    {
+        m_currentFontAtlasTexture = nullptr;
+    }
 }
 
 void TextSprite::SetText(const String& text)
 {
     m_text = text;
     UpdateTextAABB();
+    UpdateFontAtlasTexture();
 
     auto& bem = GetComponent<BoundingBoxComponent>();
     bem.worldAabb = m_textAabb;
@@ -242,6 +257,7 @@ void TextSprite::SetTextSize(float textSize)
 {
     m_textSize = textSize;
     UpdateTextAABB();
+    UpdateFontAtlasTexture();
 
     auto& bem = GetComponent<BoundingBoxComponent>();
     bem.worldAabb = m_textAabb;
@@ -273,17 +289,8 @@ void TextSprite::UpdateRenderProxy(RenderProxySprite* proxy)
     proxy->textColor = m_textColor;
     proxy->textSize = m_textSize;
     proxy->textAabb = m_textAabb;
-
-    if (const Handle<FontAtlas>& fontAtlas = GetFontAtlasOrDefault())
-    {
-        proxy->fontAtlas = fontAtlas.Get();
-        proxy->texture = fontAtlas->GetAtlasTextures().GetAtlasForPixelSize(m_textSize);
-    }
-    else
-    {
-        proxy->fontAtlas = nullptr;
-        proxy->texture = nullptr;
-    }
+    proxy->fontAtlas = m_fontAtlas.Get();
+    proxy->texture = m_currentFontAtlasTexture.Get();
 }
 
 void TextSprite::UpdateTextAABB()

--- a/Source/Engine/scene/TextSprite.hpp
+++ b/Source/Engine/scene/TextSprite.hpp
@@ -1,0 +1,80 @@
+/*!
+ *  @author: The Hyperion Contributors
+ *  @date 2016-2026
+ *  @licence MIT
+ */
+
+#pragma once
+
+#include <Core/Types.hpp>
+
+#include <Core/containers/String.hpp>
+
+#include <Core/math/Color.hpp>
+#include <Core/math/Transform.hpp>
+
+#include <Core/reflection/Handle.hpp>
+
+#include <scene/Sprite.hpp>
+
+#include <ui/font/FontAtlas.hpp>
+
+namespace Hyperion {
+
+HYP_CLASS()
+class TextSprite final : public Sprite
+{
+    HYP_OBJECT_BODY(TextSprite);
+
+public:
+    TextSprite();
+    explicit TextSprite(Name name, const String& text = "");
+
+    TextSprite(const TextSprite& other) = delete;
+    TextSprite& operator=(const TextSprite& other) = delete;
+
+    ~TextSprite() override;
+
+    void SetText(const String& text);
+    const String& GetText() const
+    {
+        return m_text;
+    }
+
+    void SetTextColor(Color color);
+    Color GetTextColor() const
+    {
+        return m_textColor;
+    }
+
+    void SetTextSize(float textSize);
+    float GetTextSize() const
+    {
+        return m_textSize;
+    }
+
+    void SetFontAtlas(const Handle<FontAtlas>& fontAtlas);
+    const Handle<FontAtlas>& GetFontAtlas() const
+    {
+        return m_fontAtlas;
+    }
+
+    const Handle<FontAtlas>& GetFontAtlasOrDefault() const;
+
+protected:
+    void Init() override;
+
+    void UpdateTextAABB();
+
+    void UpdateRenderProxy(class RenderProxySprite* proxy) override;
+
+    String m_text;
+    Color m_textColor = Color::White();
+    float m_textSize = 1.0f;
+    Handle<FontAtlas> m_fontAtlas;
+    Handle<Texture> m_currentFontAtlasTexture;
+
+    BoundingBox m_textAabb;
+};
+
+} // namespace Hyperion

--- a/Source/Engine/scene/TextSprite.hpp
+++ b/Source/Engine/scene/TextSprite.hpp
@@ -59,12 +59,18 @@ public:
         return m_fontAtlas;
     }
 
+    const Handle<Texture>& GetFontAtlasTexture() const
+    {
+        return m_currentFontAtlasTexture;
+    }
+
     const Handle<FontAtlas>& GetFontAtlasOrDefault() const;
 
 protected:
     void Init() override;
 
     void UpdateTextAABB();
+    void UpdateFontAtlasTexture();
 
     void UpdateRenderProxy(class RenderProxySprite* proxy) override;
 

--- a/Source/Engine/scene/View.cpp
+++ b/Source/Engine/scene/View.cpp
@@ -16,6 +16,7 @@
 #include <scene/ParticleVolume.hpp>
 #include <scene/FogVolume.hpp>
 #include <scene/LightmapVolume.hpp>
+#include <scene/Sprite.hpp>
 
 #include <scene/camera/Camera.hpp>
 #include <scene/animation/Skeleton.hpp>
@@ -363,8 +364,6 @@ void View::PrepareShadowViews(Array<View*, SceneTempAllocator>& outShadowViews)
 
     for (Scene* scene : m_scenes)
     {
-        AssertDebug(scene && scene->IsReady());
-
         for (auto [entity, _] : scene->GetEntityManager()->GetEntitySet<EntityType<Light>>().GetScopedView(DataAccessFlags::ACCESS_READ, HYP_FUNCTION_NAME_LIT))
         {
             Light* light = static_cast<Light*>(entity);
@@ -521,6 +520,7 @@ void View::BeginAsyncCollection(TaskBatch& batch)
             CollectFogVolumes(rpl);
             CollectEnvGrids(rpl);
             CollectEnvProbes(rpl);
+            CollectSprites(rpl);
             CollectMeshEntities(rpl);
 
             rpl.EndWrite();
@@ -598,8 +598,6 @@ void View::CollectMeshEntities(RenderProxyList& rpl)
 
     for (Scene* scene : m_scenes)
     {
-        AssertDebug(scene && scene->IsReady());
-
         if (scene->GetSceneFlags() & SceneFlags::DETACHED)
         {
             HYP_LOG(Scene, Warning, "Scene \"{}\" has DETACHED flag set, cannot collect entities for render collector!", scene->GetName());
@@ -1059,8 +1057,6 @@ void View::CollectCameras(RenderProxyList& rpl)
 
     for (Scene* scene : m_scenes)
     {
-        AssertDebug(scene != nullptr && scene->IsReady());
-
         for (auto [entity, _] : scene->GetEntityManager()->GetEntitySet<EntityType<Camera>>().GetScopedView(DataAccessFlags::ACCESS_READ, HYP_FUNCTION_NAME_LIT))
         {
             Camera* camera = static_cast<Camera*>(entity);
@@ -1081,8 +1077,6 @@ void View::CollectLights(RenderProxyList& rpl)
 
     for (Scene* scene : m_scenes)
     {
-        AssertDebug(scene && scene->IsReady());
-
         for (auto [entity, _] : scene->GetEntityManager()->GetEntitySet<EntityType<Light>>().GetScopedView(DataAccessFlags::ACCESS_READ, HYP_FUNCTION_NAME_LIT))
         {
             Light* light = static_cast<Light*>(entity);
@@ -1150,8 +1144,6 @@ void View::CollectLightmapVolumes(RenderProxyList& rpl)
 
     for (Scene* scene : m_scenes)
     {
-        AssertDebug(scene && scene->IsReady());
-
         for (auto [entity, _] : scene->GetEntityManager()->GetEntitySet<EntityType<LightmapVolume>>().GetScopedView(DataAccessFlags::ACCESS_READ, HYP_FUNCTION_NAME_LIT))
         {
             LightmapVolume* lightmapVolume = DynamicCast<LightmapVolume>(entity);
@@ -1192,8 +1184,6 @@ void View::CollectParticleVolumes(RenderProxyList& rpl)
 
     for (Scene* scene : m_scenes)
     {
-        AssertDebug(scene && scene->IsReady());
-
         for (auto [entity, _] : scene->GetEntityManager()->GetEntitySet<EntityType<ParticleVolume>>().GetScopedView(DataAccessFlags::ACCESS_READ, HYP_FUNCTION_NAME_LIT))
         {
             ParticleVolume* volume = static_cast<ParticleVolume*>(entity);
@@ -1235,8 +1225,6 @@ void View::CollectFogVolumes(RenderProxyList& rpl)
 
     for (Scene* scene : m_scenes)
     {
-        AssertDebug(scene && scene->IsReady());
-
         for (auto [entity, _] : scene->GetEntityManager()->GetEntitySet<EntityType<FogVolume>>().GetScopedView(DataAccessFlags::ACCESS_READ, HYP_FUNCTION_NAME_LIT))
         {
             FogVolume* volume = static_cast<FogVolume*>(entity);
@@ -1278,8 +1266,6 @@ void View::CollectEnvGrids(RenderProxyList& rpl)
 
     for (Scene* scene : m_scenes)
     {
-        AssertDebug(scene && scene->IsReady());
-
         for (auto [entity, _] : scene->GetEntityManager()->GetEntitySet<EntityType<EnvGrid>>().GetScopedView(DataAccessFlags::ACCESS_READ, HYP_FUNCTION_NAME_LIT))
         {
             EnvGrid* envGrid = static_cast<EnvGrid*>(entity);
@@ -1321,8 +1307,6 @@ void View::CollectEnvProbes(RenderProxyList& rpl)
 
     for (Scene* scene : m_scenes)
     {
-        AssertDebug(scene && scene->IsReady());
-
         for (auto [entity, _] : scene->GetEntityManager()->GetEntitySet<EntityType<EnvProbe>>().GetScopedView(DataAccessFlags::ACCESS_READ, HYP_FUNCTION_NAME_LIT))
         {
             EnvProbe* probe = static_cast<EnvProbe*>(entity);
@@ -1350,6 +1334,26 @@ void View::CollectEnvProbes(RenderProxyList& rpl)
             }
 
             rpl.GetEnvProbes().Track(probe->Id(), probe, probe->GetRenderProxyVersionPtr());
+        }
+    }
+}
+
+void View::CollectSprites(RenderProxyList& rpl)
+{
+    HYP_SCOPE;
+
+    if (m_flags & ViewFlags::SKIP_SPRITES)
+    {
+        return;
+    }
+
+    for (Scene* scene : m_scenes)
+    {
+        for (auto [entity, _] : scene->GetEntityManager()->GetEntitySet<EntityType<Sprite>>().GetScopedView(DataAccessFlags::ACCESS_READ, HYP_FUNCTION_NAME_LIT))
+        {
+            Sprite* sprite = static_cast<Sprite*>(entity);
+
+            rpl.GetSprites().Track(sprite->Id(), sprite, sprite->GetRenderProxyVersionPtr());
         }
     }
 }

--- a/Source/Engine/scene/View.cpp
+++ b/Source/Engine/scene/View.cpp
@@ -17,6 +17,7 @@
 #include <scene/FogVolume.hpp>
 #include <scene/LightmapVolume.hpp>
 #include <scene/Sprite.hpp>
+#include <scene/TextSprite.hpp>
 
 #include <scene/camera/Camera.hpp>
 #include <scene/animation/Skeleton.hpp>
@@ -1354,6 +1355,16 @@ void View::CollectSprites(RenderProxyList& rpl)
             Sprite* sprite = static_cast<Sprite*>(entity);
 
             rpl.GetSprites().Track(sprite->Id(), sprite, sprite->GetRenderProxyVersionPtr());
+
+            if (sprite->IsA<TextSprite>())
+            {
+                TextSprite* textSprite = static_cast<TextSprite*>(sprite);
+
+                if (Texture* fontAtlasTexture = textSprite->GetFontAtlasTexture())
+                {
+                    rpl.GetTextures().Track(fontAtlasTexture->Id(), fontAtlasTexture);
+                }
+            }
         }
     }
 }

--- a/Source/Engine/scene/View.cpp
+++ b/Source/Engine/scene/View.cpp
@@ -115,7 +115,12 @@ const Handle<GBuffer>& ViewOutputTarget::GetGBuffer() const
         return Handle<GBuffer>::Null();
     }
 
-    return ObjCast<GBuffer>(m_impl);
+    if (m_impl->IsA<GBuffer>())
+    {
+        return StaticCast<GBuffer>(m_impl);
+    }
+
+    return Handle<GBuffer>::Null();
 }
 
 const FramebufferRef& ViewOutputTarget::GetFramebuffer() const
@@ -125,12 +130,12 @@ const FramebufferRef& ViewOutputTarget::GetFramebuffer() const
         return FramebufferRef::Null();
     }
 
-    if (m_impl->IsA(GBuffer::StaticClass()))
+    if (m_impl->IsA<GBuffer>())
     {
-        return static_cast<GBuffer&>(*m_impl).GetBucket(RenderBucket::Opaque).GetFramebuffer();
+        return StaticCast<GBuffer>(m_impl)->GetBucket(RenderBucket::Opaque).GetFramebuffer();
     }
 
-    return ObjCast<Framebuffer>(m_impl);
+    return StaticCast<Framebuffer>(m_impl);
 }
 
 const FramebufferRef& ViewOutputTarget::GetFramebuffer(RenderBucket rb) const
@@ -140,12 +145,12 @@ const FramebufferRef& ViewOutputTarget::GetFramebuffer(RenderBucket rb) const
         return FramebufferRef::Null();
     }
 
-    if (m_impl->IsA(GBuffer::StaticClass()))
+    if (m_impl->IsA<GBuffer>())
     {
-        return static_cast<GBuffer&>(*m_impl).GetBucket(rb).GetFramebuffer();
+        return StaticCast<GBuffer>(m_impl)->GetBucket(rb).GetFramebuffer();
     }
 
-    return ObjCast<Framebuffer>(m_impl);
+    return StaticCast<Framebuffer>(m_impl);
 }
 
 Span<const FramebufferRef> ViewOutputTarget::GetFramebuffers() const
@@ -157,10 +162,10 @@ Span<const FramebufferRef> ViewOutputTarget::GetFramebuffers() const
 
     if (m_impl->IsA(GBuffer::StaticClass()))
     {
-        return static_cast<GBuffer&>(*m_impl).GetFramebuffers();
+        return StaticCast<GBuffer>(m_impl)->GetFramebuffers();
     }
 
-    return { &ObjCast<Framebuffer>(m_impl), 1 };
+    return { &StaticCast<Framebuffer>(m_impl), 1 };
 }
 
 #pragma endregion ViewOutputTarget
@@ -999,7 +1004,7 @@ void View::CollectMeshEntities(RenderProxyList& rpl)
 
                 AssertDebug(meshComponent->instanceData.IsLoaded());
 
-                const Handle<InstancedMeshData>& imd = ObjCast<InstancedMeshData>(meshComponent->instanceData.Resolve());
+                const Handle<InstancedMeshData>& imd = DynamicCast<InstancedMeshData>(meshComponent->instanceData.Resolve());
                 AssertDebug(imd.IsValid());
 
                 if (imd.IsValid())
@@ -1149,7 +1154,7 @@ void View::CollectLightmapVolumes(RenderProxyList& rpl)
 
         for (auto [entity, _] : scene->GetEntityManager()->GetEntitySet<EntityType<LightmapVolume>>().GetScopedView(DataAccessFlags::ACCESS_READ, HYP_FUNCTION_NAME_LIT))
         {
-            LightmapVolume* lightmapVolume = ObjCast<LightmapVolume>(entity);
+            LightmapVolume* lightmapVolume = DynamicCast<LightmapVolume>(entity);
             Assert(lightmapVolume != nullptr);
 
             const BoundingBox worldBounds = lightmapVolume->GetWorldBounds();

--- a/Source/Engine/scene/View.hpp
+++ b/Source/Engine/scene/View.hpp
@@ -69,11 +69,12 @@ enum class ViewFlags : uint32
     SKIP_PARTICLE_VOLUMES = 0x200,      //!< If set, the view will not collect ParticleVolumes.
     SKIP_FOG_VOLUMES = 0x400,           //!< If set, the view will not collect FogVolumes.
     SKIP_CAMERAS = 0x800,               //!< If set, the view will not collect Cameras.
+    SKIP_SPRITES = 0x1000,              //!< If set, the view will not collect Sprites.
 
-    NOT_MULTI_BUFFERED = 0x1000,        //!< Disables double / triple buffering for the RenderProxyList this View writes to.
+    NOT_MULTI_BUFFERED = 0x2000,        //!< Disables double / triple buffering for the RenderProxyList this View writes to.
                                         //  --- Use ONLY for Views that are not written to every frame, and instead are written to and read once (or infrequently); e.g EnvProbes.
                                         //  --- Use of these is still threadsafe, however it uses a spinlock instead of multiple buffering so contentions will eat up cpu cycles.
-    NO_DRAW_CALLS = 0x2000,             //!< If set, no draw calls will be built for any mesh entities that this View collects.
+    NO_DRAW_CALLS = 0x4000,             //!< If set, no draw calls will be built for any mesh entities that this View collects.
 
     // enable flags
     RAY_TRACING = 0x100000,             //!< Does this View contain rayTracing data (acceleration structures)? (RayTracing must be enabled in the global config and must have RT hardware support)
@@ -267,6 +268,7 @@ protected:
     void CollectFogVolumes(RenderProxyList& rpl);
     void CollectEnvGrids(RenderProxyList& rpl);
     void CollectEnvProbes(RenderProxyList& rpl);
+    void CollectSprites(RenderProxyList& rpl);
     void CollectMeshEntities(RenderProxyList& rpl);
 
     ViewDesc m_viewDesc;

--- a/Source/Engine/scene/World.cpp
+++ b/Source/Engine/scene/World.cpp
@@ -23,6 +23,10 @@
 #include <scene/systems/ScriptSystem.hpp>
 #include <scene/systems/MeshSystem.hpp>
 
+#if HYP_EDITOR
+#include <scene/systems/editor/EditorSpriteSystem.hpp>
+#endif // HYP_EDITOR
+
 #include <scene/components/MeshComponent.hpp>
 #include <scene/components/TransformComponent.hpp>
 #include <scene/components/BoundingBoxComponent.hpp>
@@ -334,6 +338,11 @@ void World::Init()
 
     if (!HasSystem<MeshSystem>())
         AddSystem(MakeHandle<MeshSystem>());
+
+#if HYP_EDITOR
+    if (!HasSystem<EditorSpriteSystem>())
+        AddSystem(MakeHandle<EditorSpriteSystem>());
+#endif // HYP_EDITOR
 
     for (View* view : m_views)
     {

--- a/Source/Engine/scene/World.cpp
+++ b/Source/Engine/scene/World.cpp
@@ -1314,7 +1314,7 @@ static void BindStreamingDelegates(DelegateHandlerSet& set, World* world, WorldG
             {
                 if (obj->IsA(Scene::StaticClass()))
                 {
-                    const Scene* scene = ObjCast<Scene>(obj);
+                    const Scene* scene = DynamicCast<Scene>(obj);
 
                     world->AddScene(MakeStrongRef(scene), /* addToStreamingLayer */ false);
 
@@ -1330,7 +1330,7 @@ static void BindStreamingDelegates(DelegateHandlerSet& set, World* world, WorldG
             {
                 if (obj->IsA(Scene::StaticClass()))
                 {
-                    const Scene* scene = ObjCast<Scene>(obj);
+                    const Scene* scene = DynamicCast<Scene>(obj);
 
                     world->RemoveScene(const_cast<Scene*>(scene), /* removeFromStreamingLayer */ false);
 

--- a/Source/Engine/scene/World.cpp
+++ b/Source/Engine/scene/World.cpp
@@ -23,10 +23,6 @@
 #include <scene/systems/ScriptSystem.hpp>
 #include <scene/systems/MeshSystem.hpp>
 
-#if HYP_EDITOR
-#include <scene/systems/editor/EditorSpriteSystem.hpp>
-#endif // HYP_EDITOR
-
 #include <scene/components/MeshComponent.hpp>
 #include <scene/components/TransformComponent.hpp>
 #include <scene/components/BoundingBoxComponent.hpp>
@@ -338,11 +334,6 @@ void World::Init()
 
     if (!HasSystem<MeshSystem>())
         AddSystem(MakeHandle<MeshSystem>());
-
-#if HYP_EDITOR
-    if (!HasSystem<EditorSpriteSystem>())
-        AddSystem(MakeHandle<EditorSpriteSystem>());
-#endif // HYP_EDITOR
 
     for (View* view : m_views)
     {

--- a/Source/Engine/scene/World.hpp
+++ b/Source/Engine/scene/World.hpp
@@ -183,7 +183,7 @@ public:
     {
         static_assert(std::is_base_of_v<Subsystem, T>, "T must be a subclass of Subsystem");
 
-        return ObjCast<T>(AddSubsystem(TypeId::ForType<T>(), MakeHandle<T>()));
+        return DynamicCast<T>(AddSubsystem(TypeId::ForType<T>(), MakeHandle<T>()));
     }
 
     template <class T>
@@ -191,7 +191,7 @@ public:
     {
         static_assert(std::is_base_of_v<Subsystem, T>, "T must be a subclass of Subsystem");
 
-        return ObjCast<T>(AddSubsystem(TypeId::ForType<T>(), subsystem));
+        return DynamicCast<T>(AddSubsystem(TypeId::ForType<T>(), subsystem));
     }
 
     const Handle<Subsystem>& AddSubsystem(TypeId typeId, const Handle<Subsystem>& subsystem);
@@ -204,7 +204,7 @@ public:
     {
         static_assert(std::is_base_of_v<Subsystem, T>, "T must be a subclass of Subsystem");
 
-        return ObjCast<T>(GetSubsystem(TypeId::ForType<T>()));
+        return DynamicCast<T>(GetSubsystem(TypeId::ForType<T>()));
     }
 
     Subsystem* GetSubsystem(TypeId typeId) const;
@@ -303,7 +303,7 @@ public:
 
         if (it != m_systems.End())
         {
-            return ObjCast<SystemType>(*it);
+            return DynamicCast<SystemType>(*it);
         }
 
         it = m_systems.FindIf([](const Handle<SystemBase>& system)
@@ -313,7 +313,7 @@ public:
 
         if (it != m_systems.End())
         {
-            return ObjCast<SystemType>(*it);
+            return DynamicCast<SystemType>(*it);
         }
 
         return nullptr;

--- a/Source/Engine/scene/animation/Skeleton.cpp
+++ b/Source/Engine/scene/animation/Skeleton.cpp
@@ -80,7 +80,7 @@ Bone* Skeleton::FindBone(StringHash name) const
             continue;
         }
 
-        Bone* bone = ObjCast<Bone>(node);
+        Bone* bone = DynamicCast<Bone>(node);
 
         if (!bone)
         {
@@ -121,7 +121,7 @@ uint32 Skeleton::FindBoneIndex(StringHash name) const
             continue;
         }
 
-        Bone* bone = ObjCast<Bone>(node);
+        Bone* bone = DynamicCast<Bone>(node);
 
         if (!bone)
         {
@@ -189,7 +189,7 @@ void Skeleton::UpdateRenderProxy(RenderProxySkeleton* proxy)
                 continue;
             }
 
-            Bone* bone = ObjCast<Bone>(descendant);
+            Bone* bone = DynamicCast<Bone>(descendant);
 
             if (!bone)
             {

--- a/Source/Engine/scene/systems/CharacterControllerSystem.cpp
+++ b/Source/Engine/scene/systems/CharacterControllerSystem.cpp
@@ -150,7 +150,7 @@ void CharacterControllerSystem::Process(float delta, Span<Handle<Scene>> scenes)
 
             if (component.inputHandler)
             {
-                CharacterControllerInputHandler* inputHandler = ObjCast<CharacterControllerInputHandler>(component.inputHandler.Get());
+                CharacterControllerInputHandler* inputHandler = DynamicCast<CharacterControllerInputHandler>(component.inputHandler.Get());
 
                 if (inputHandler)
                 {

--- a/Source/Engine/scene/systems/LightmapSystem.cpp
+++ b/Source/Engine/scene/systems/LightmapSystem.cpp
@@ -54,7 +54,7 @@ bool LightmapSystem::AssignLightmapVolume(
 {
     for (auto [entity, _] : scene->GetEntityManager()->GetEntitySet<EntityType<LightmapVolume>>().GetScopedView(GetComponentInfos()))
     {
-        LightmapVolume* lightmapVolume = ObjCast<LightmapVolume>(entity);
+        LightmapVolume* lightmapVolume = DynamicCast<LightmapVolume>(entity);
         Assert(lightmapVolume != nullptr);
 
         if (lightmapElementComponent.lightmapVolume.GetUnsafe() != lightmapVolume

--- a/Source/Engine/scene/systems/MeshSystem.cpp
+++ b/Source/Engine/scene/systems/MeshSystem.cpp
@@ -58,7 +58,7 @@ void UpdateInstancedMeshData(Entity& entity, MeshComponent& meshComponent)
         meshComponent.instanceData = AssetReference(imd);
     }
     
-    const Handle<InstancedMeshData>& imd = ObjCast<InstancedMeshData>(meshComponent.instanceData.Resolve());
+    const Handle<InstancedMeshData>& imd = DynamicCast<InstancedMeshData>(meshComponent.instanceData.Resolve());
 
     if (!imd.IsValid())
     {

--- a/Source/Engine/scene/systems/editor/EditorSpriteSystem.cpp
+++ b/Source/Engine/scene/systems/editor/EditorSpriteSystem.cpp
@@ -15,6 +15,7 @@
 #include <scene/World.hpp>
 #include <scene/EnvProbe.hpp>
 #include <scene/LightmapVolume.hpp>
+#include <scene/TextSprite.hpp>
 
 #include <scene/camera/Camera.hpp>
 
@@ -77,7 +78,8 @@ void EditorSpriteSystem::OnEntityAdded(Entity* entity)
     {
         if (!camera->HasTag<EntityTag::EditorCamera>())
         {
-            sprite = Sprite::CreateCameraSprite(scene, camera);
+            sprite = MakeHandle<TextSprite>(NAME_FMT("{}_Sprite_Text", camera->GetName()), *camera->GetName());
+            scene->GetRoot()->AddChild(sprite);
         }
     }
 

--- a/Source/Engine/scene/systems/editor/EditorSpriteSystem.cpp
+++ b/Source/Engine/scene/systems/editor/EditorSpriteSystem.cpp
@@ -15,12 +15,16 @@
 #include <scene/World.hpp>
 #include <scene/EnvProbe.hpp>
 #include <scene/LightmapVolume.hpp>
+
 #include <scene/camera/Camera.hpp>
+
 #include <editor/EditorSubsystem.hpp>
 
 #include <EditorSpriteSystem.generated.inl>
 
 namespace Hyperion {
+
+HYP_DECLARE_LOG_CHANNEL(Editor);
 
 void EditorSpriteSystem::OnEntityAdded(Entity* entity)
 {
@@ -32,17 +36,33 @@ void EditorSpriteSystem::OnEntityAdded(Entity* entity)
         return;
     }
 
-    // Must be both foreground scene and editor scene.
-    if ((scene->GetSceneFlags() & (SceneFlags::FOREGROUND | SceneFlags::EDITOR)) != (SceneFlags::FOREGROUND | SceneFlags::EDITOR))
+    if (!(scene->GetSceneFlags() & SceneFlags::FOREGROUND)
+        || (scene->GetSceneFlags() & (SceneFlags::UI | SceneFlags::EDITOR)))
     {
         return;
     }
+
+    //Scene* editorScene = nullptr;
+
+    //auto editorSceneIt = GetWorld()->GetScenes().FindIf([](const Handle<Scene>& scene)
+    //    {
+    //        return scene->GetSceneFlags() & SceneFlags::EDITOR;
+    //    });
+
+    //if (editorSceneIt == GetWorld()->GetScenes().End())
+    //{
+    //    HYP_LOG(Editor, Error, "No Editor scene found! Cannot add editor sprite");
+
+    //    return;
+    //}
+
+    //editorScene = *editorSceneIt;
 
     Handle<Sprite> sprite;
     
     if (EnvProbe* envProbe = DynamicCast<EnvProbe>(entity))
     {
-        if (envProbe->IsSkyProbe())
+        if (envProbe->IsA<SkyProbe>())
         {
             return;
         }
@@ -55,7 +75,10 @@ void EditorSpriteSystem::OnEntityAdded(Entity* entity)
     }
     else if (Camera* camera = DynamicCast<Camera>(entity))
     {
-        sprite = Sprite::CreateCameraSprite(scene, camera);
+        if (!camera->HasTag<EntityTag::EditorCamera>())
+        {
+            sprite = Sprite::CreateCameraSprite(scene, camera);
+        }
     }
 
     if (sprite.IsValid())

--- a/Source/Engine/scene/systems/editor/EditorSpriteSystem.cpp
+++ b/Source/Engine/scene/systems/editor/EditorSpriteSystem.cpp
@@ -1,0 +1,101 @@
+/*!
+ *  @author: The Hyperion Contributors
+ *  @date 2016-2026
+ *  @licence MIT
+ */
+
+#include <ScenePch.hpp>
+
+#if HYP_EDITOR
+
+#include <scene/systems/editor/EditorSpriteSystem.hpp>
+
+#include <scene/EntityManager.hpp>
+#include <scene/Scene.hpp>
+#include <scene/EnvProbe.hpp>
+#include <scene/LightmapVolume.hpp>
+#include <scene/camera/Camera.hpp>
+
+#include <EditorSpriteSystem.generated.inl>
+
+namespace Hyperion {
+
+void EditorSpriteSystem::OnEntityAdded(Entity* entity)
+{
+    SystemBase::OnEntityAdded(entity);
+
+    Scene* scene = entity->GetScene();
+    if (!scene)
+    {
+        return;
+    }
+
+    Handle<Sprite> sprite;
+    
+    if (EnvProbe* envProbe = DynamicCast<EnvProbe>(entity))
+    {
+        if (envProbe->IsSkyProbe())
+        {
+            return;
+        }
+        
+        sprite = Sprite::CreateEnvProbeSprite(scene, envProbe);
+    }
+    else if (LightmapVolume* lightmapVolume = DynamicCast<LightmapVolume>(entity))
+    {
+        sprite = Sprite::CreateLightmapVolumeSprite(scene, lightmapVolume);
+    }
+    else if (Camera* camera = DynamicCast<Camera>(entity))
+    {
+        sprite = Sprite::CreateCameraSprite(scene, camera);
+    }
+
+    if (sprite.IsValid())
+    {
+        SpriteMapping mapping;
+        mapping.sprite = sprite;
+        mapping.trackedEntity = entity;
+        m_spriteMappings.PushBack(mapping);
+    }
+}
+
+void EditorSpriteSystem::OnEntityRemoved(Entity* entity)
+{
+    SystemBase::OnEntityRemoved(entity);
+
+    for (size_t i = 0; i < m_spriteMappings.Size(); ++i)
+    {
+        if (m_spriteMappings[i].trackedEntity == entity)
+        {
+            m_spriteMappings[i].sprite->Remove();
+            m_spriteMappings.EraseAt(i);
+            break;
+        }
+    }
+}
+
+void EditorSpriteSystem::Process(float delta, Span<Handle<Scene>> scenes)
+{
+    for (auto& mapping : m_spriteMappings)
+    {
+        if (mapping.sprite.IsValid() && mapping.trackedEntity)
+        {
+            if (EnvProbe* envProbe = DynamicCast<EnvProbe>(mapping.trackedEntity))
+            {
+                mapping.sprite->SetWorldTranslation(envProbe->GetWorldBounds().GetCenter());
+            }
+            else if (LightmapVolume* lightmapVolume = DynamicCast<LightmapVolume>(mapping.trackedEntity))
+            {
+                mapping.sprite->SetWorldTranslation(lightmapVolume->GetWorldBounds().GetCenter());
+            }
+            else if (Camera* camera = DynamicCast<Camera>(mapping.trackedEntity))
+            {
+                mapping.sprite->SetWorldTranslation(camera->GetWorldTranslation());
+            }
+        }
+    }
+}
+
+} // namespace Hyperion
+
+#endif // HYP_EDITOR

--- a/Source/Engine/scene/systems/editor/EditorSpriteSystem.cpp
+++ b/Source/Engine/scene/systems/editor/EditorSpriteSystem.cpp
@@ -12,9 +12,11 @@
 
 #include <scene/EntityManager.hpp>
 #include <scene/Scene.hpp>
+#include <scene/World.hpp>
 #include <scene/EnvProbe.hpp>
 #include <scene/LightmapVolume.hpp>
 #include <scene/camera/Camera.hpp>
+#include <editor/EditorSubsystem.hpp>
 
 #include <EditorSpriteSystem.generated.inl>
 
@@ -26,6 +28,12 @@ void EditorSpriteSystem::OnEntityAdded(Entity* entity)
 
     Scene* scene = entity->GetScene();
     if (!scene)
+    {
+        return;
+    }
+
+    // Must be both foreground scene and editor scene.
+    if ((scene->GetSceneFlags() & (SceneFlags::FOREGROUND | SceneFlags::EDITOR)) != (SceneFlags::FOREGROUND | SceneFlags::EDITOR))
     {
         return;
     }
@@ -76,6 +84,7 @@ void EditorSpriteSystem::OnEntityRemoved(Entity* entity)
 
 void EditorSpriteSystem::Process(float delta, Span<Handle<Scene>> scenes)
 {
+#if 0
     for (auto& mapping : m_spriteMappings)
     {
         if (mapping.sprite.IsValid() && mapping.trackedEntity)
@@ -94,6 +103,7 @@ void EditorSpriteSystem::Process(float delta, Span<Handle<Scene>> scenes)
             }
         }
     }
+#endif
 }
 
 } // namespace Hyperion

--- a/Source/Engine/scene/systems/editor/EditorSpriteSystem.hpp
+++ b/Source/Engine/scene/systems/editor/EditorSpriteSystem.hpp
@@ -1,0 +1,47 @@
+/*!
+ *  @author: The Hyperion Contributors
+ *  @date 2016-2026
+ *  @licence MIT
+ */
+
+#pragma once
+
+#include <scene/System.hpp>
+
+#include <scene/Sprite.hpp>
+
+#include <scene/EnvProbe.hpp>
+#include <scene/LightmapVolume.hpp>
+#include <scene/camera/Camera.hpp>
+
+namespace Hyperion {
+
+HYP_CLASS(EditorOnly, NoScriptBindings)
+class HYP_API EditorSpriteSystem final : public SystemBase
+{
+    HYP_OBJECT_BODY(EditorSpriteSystem);
+
+public:
+    ~EditorSpriteSystem() override = default;
+
+    void OnEntityAdded(Entity* entity) override;
+    void OnEntityRemoved(Entity* entity) override;
+
+    void Process(float delta, Span<Handle<Scene>> scenes) override;
+
+private:
+    SystemComponentDescriptors GetComponentDescriptors() const override
+    {
+        return {};
+    }
+
+    struct SpriteMapping
+    {
+        Handle<Sprite> sprite;
+        Entity* trackedEntity;
+    };
+
+    Array<SpriteMapping, SceneAllocator> m_spriteMappings;
+};
+
+} // namespace Hyperion

--- a/Source/Engine/scene/systems/editor/EditorSpriteSystem.hpp
+++ b/Source/Engine/scene/systems/editor/EditorSpriteSystem.hpp
@@ -7,11 +7,12 @@
 #pragma once
 
 #include <scene/System.hpp>
-
 #include <scene/Sprite.hpp>
-
 #include <scene/EnvProbe.hpp>
 #include <scene/LightmapVolume.hpp>
+
+#include <scene/components/TransformComponent.hpp>
+
 #include <scene/camera/Camera.hpp>
 
 namespace Hyperion {
@@ -32,7 +33,9 @@ public:
 private:
     SystemComponentDescriptors GetComponentDescriptors() const override
     {
-        return {};
+        return {
+            ComponentDescriptor<TransformComponent, ComponentAccess::READ> {}
+        };
     }
 
     struct SpriteMapping

--- a/Source/Engine/scripting/ScriptableDelegate.hpp
+++ b/Source/Engine/scripting/ScriptableDelegate.hpp
@@ -31,7 +31,7 @@ namespace functional {
 
 HYP_API void LogScriptableDelegateError(const char* message, dotnet::ManagedObject* objectPtr);
 
-class IScriptableDelegate : public virtual IDelegate
+class IScriptableDelegate
 {
 public:
     virtual ~IScriptableDelegate() = default;
@@ -42,6 +42,10 @@ public:
 #ifdef HYP_DOTNET
     virtual HYP_NODISCARD DelegateHandler BindMethod(ANSIStringView methodName, UniquePtr<dotnet::ManagedObject>&& object) = 0;
 #endif
+
+    virtual int RemoveAllDetached() = 0;
+
+    virtual bool Remove(DelegateHandler&& handle) = 0;
 };
 
 class ScriptableDelegateHelper
@@ -151,7 +155,7 @@ public:
  *  \tparam ReturnType The return type of the delegate.
  *  \tparam Args The argument types of the delegate.*/
 template <class ReturnType, class... Args>
-class ScriptableDelegate final : public IScriptableDelegate, public virtual Delegate<ReturnType, Args...>
+class ScriptableDelegate final : public IScriptableDelegate, public Delegate<ReturnType, Args...>
 {
 public:
     using ProcType = Proc<ReturnType(Args...)>;
@@ -321,7 +325,17 @@ public:
                 return object->InvokeMethodByName<ReturnType>(methodName, std::forward<ArgTypes>(args)...);
             });
     }
-#endif
+#endif // HYP_DOTNET
+
+    virtual int RemoveAllDetached() override
+    {
+        return Delegate<ReturnType, Args...>::RemoveAllDetached();
+    }
+
+    virtual bool Remove(DelegateHandler&& handle) override
+    {
+        return Delegate<ReturnType, Args...>::Remove(std::move(handle));
+    }
 
     /*! \brief Call operator overload - alias method for Broadcast().
      *  \tparam ArgTypes The argument types to pass to the handlers.

--- a/Source/Engine/system/AppContext.cpp
+++ b/Source/Engine/system/AppContext.cpp
@@ -718,7 +718,7 @@ VkSurfaceKHR SDLAppContext::CreateVulkanSurface(
 
     VkSurfaceKHR surface = VK_NULL_HANDLE;
 
-    SDLApplicationWindow* sdlWindow = ObjCast<SDLApplicationWindow>(window);
+    SDLApplicationWindow* sdlWindow = DynamicCast<SDLApplicationWindow>(window);
     Assert(sdlWindow != nullptr);
 
     SDL_bool result = SDL_Vulkan_CreateSurface(
@@ -1593,7 +1593,7 @@ VkSurfaceKHR Win32AppContext::CreateVulkanSurface(
 
     if (window != nullptr)
     {
-        Win32ApplicationWindow* win32Window = ObjCast<Win32ApplicationWindow>(window);
+        Win32ApplicationWindow* win32Window = DynamicCast<Win32ApplicationWindow>(window);
         Assert(win32Window != nullptr);
 
         if (win32Window->GetVkSurface() != VK_NULL_HANDLE)

--- a/Source/Engine/system/AppContext.cpp
+++ b/Source/Engine/system/AppContext.cpp
@@ -800,8 +800,6 @@ struct Win32WindowRegistry
 
 } // namespace
 
-static constexpr const wchar_t* WindowClassName = L"HyperionRenderWindow";
-
 void Win32_RegisterWindowClass(const WideString& className)
 {
     Win32WindowRegistry::GetInstance().Register(className);

--- a/Source/Engine/system/platform/android/AndroidAppContext.cpp
+++ b/Source/Engine/system/platform/android/AndroidAppContext.cpp
@@ -285,7 +285,7 @@ void AndroidAppContext::SetNativeWindow(void* nativeWindow)
         return;
     }
 
-    AndroidApplicationWindow* androidWindow = ObjCast<AndroidApplicationWindow>(m_mainWindow);
+    AndroidApplicationWindow* androidWindow = DynamicCast<AndroidApplicationWindow>(m_mainWindow);
     Assert(androidWindow != nullptr);
 
     androidWindow->SetNativeWindow(nativeWindow);

--- a/Source/Engine/system/platform/mac/CocoaAppContext.mm
+++ b/Source/Engine/system/platform/mac/CocoaAppContext.mm
@@ -278,7 +278,7 @@ VkSurfaceKHR CocoaAppContext::CreateVulkanSurface(
 
     if (window)
     {
-        CocoaApplicationWindow* cocoaWindow = ObjCast<CocoaApplicationWindow>(window);
+        CocoaApplicationWindow* cocoaWindow = DynamicCast<CocoaApplicationWindow>(window);
         Assert(cocoaWindow != nullptr);
         __block CAMetalLayer* layer = (CAMetalLayer*)cocoaWindow->GetCAMetalLayer();
 

--- a/Source/Engine/ui/UIGrid.cpp
+++ b/Source/Engine/ui/UIGrid.cpp
@@ -56,7 +56,7 @@ void UIGridRow::AddChildUIObject(const Handle<UIObject>& uiObject)
     {
         UIObject::AddChildUIObject(uiObject);
 
-        m_columns.PushBack(ObjCast<UIGridColumn>(uiObject));
+        m_columns.PushBack(DynamicCast<UIGridColumn>(uiObject));
 
         UpdateColumnSizes();
         UpdateColumnOffsets();
@@ -342,7 +342,7 @@ void UIGrid::AddChildUIObject(const Handle<UIObject>& uiObject)
         return;
     }
 
-    if (const Handle<UIGridRow>& row = ObjCast<UIGridRow>(uiObject))
+    if (const Handle<UIGridRow>& row = DynamicCast<UIGridRow>(uiObject))
     {
         row->SetNumColumns(m_numColumns);
 

--- a/Source/Engine/ui/UIListView.cpp
+++ b/Source/Engine/ui/UIListView.cpp
@@ -265,7 +265,7 @@ void UIListView::AddChildUIObject(const Handle<UIObject>& uiObject)
 
     if (uiObject->IsA<UIListViewItem>())
     {
-        listViewItem = ObjCast<UIListViewItem>(uiObject);
+        listViewItem = DynamicCast<UIListViewItem>(uiObject);
         listViewItem->SetSize(listViewItemSize);
         m_listViewItems.PushBack(listViewItem);
 
@@ -466,7 +466,7 @@ UIListViewItem* UIListView::FindListViewItem(const UIObject* parentObject, const
         {
             if (object->IsA<UIListViewItem>() && object->GetDataSourceElementUUID() == dataSourceElementUuid)
             {
-                resultPtr = ObjCast<UIListViewItem>(object);
+                resultPtr = DynamicCast<UIListViewItem>(object);
 
                 return IterationResult::STOP;
             }
@@ -601,7 +601,7 @@ void UIListView::SetSelectedItem(UIListViewItem* listViewItem)
 
         while (parent != nullptr && parent != this)
         {
-            if (UIListViewItem* parentListViewItem = ObjCast<UIListViewItem>(parent))
+            if (UIListViewItem* parentListViewItem = DynamicCast<UIListViewItem>(parent))
             {
                 if (!parentListViewItem->IsExpanded())
                 {

--- a/Source/Engine/ui/UIMenuBar.cpp
+++ b/Source/Engine/ui/UIMenuBar.cpp
@@ -105,7 +105,7 @@ void UIMenuItem::AddChildUIObject(const Handle<UIObject>& uiObject)
         return;
     }
 
-    if (Handle<UIMenuItem> menuItem = ObjCast<UIMenuItem>(uiObject))
+    if (Handle<UIMenuItem> menuItem = DynamicCast<UIMenuItem>(uiObject))
     {
         menuItem->OnMouseHover
             .Bind([weakThis = WeakHandleFromThis(), subMenuItemWeak = menuItem.ToWeak()](const MouseEvent& event) -> UIEventHandlerResult
@@ -572,7 +572,7 @@ void UIMenuBar::AddChildUIObject(const Handle<UIObject>& uiObject)
 
     UIPanel::AddChildUIObject(uiObject);
 
-    if (UIMenuItem* menuItem = ObjCast<UIMenuItem>(uiObject))
+    if (UIMenuItem* menuItem = DynamicCast<UIMenuItem>(uiObject))
     {
         menuItem->SetSize(UIObjectSize({ 100, UIObjectSize::FILL }, { 100, UIObjectSize::PERCENT }));
 
@@ -801,7 +801,7 @@ void UIMenuBar::UpdateMenuItemSizes()
 
         const Vec2i childPadding = childUiObjects[i]->GetPadding();
 
-        if (UISpacer* spacer = ObjCast<UISpacer>(childUiObject))
+        if (UISpacer* spacer = DynamicCast<UISpacer>(childUiObject))
         {
             spacer->SetSize(UIObjectSize({ spacerWidth, UIObjectSize::PIXEL }, { 100, UIObjectSize::PERCENT }));
 

--- a/Source/Engine/ui/UIObject.cpp
+++ b/Source/Engine/ui/UIObject.cpp
@@ -2033,7 +2033,7 @@ UIObject* UIObject::GetParentUIObject() const
 
     while (parentNode != nullptr)
     {
-        if (Entity* entity = ObjCast<Entity>(parentNode))
+        if (Entity* entity = DynamicCast<Entity>(parentNode))
         {
             if (UIComponent* uiComponent = entity->TryGetComponent<UIComponent>())
             {
@@ -2072,7 +2072,7 @@ Handle<UIObject> UIObject::GetClosestParentUIObject_Proc(const ProcRef<bool(UIOb
 
     while (parentNode)
     {
-        if (Entity* entity = ObjCast<Entity>(parentNode))
+        if (Entity* entity = DynamicCast<Entity>(parentNode))
         {
             if (UIComponent* uiComponent = entity->TryGetComponent<UIComponent>())
             {
@@ -2203,7 +2203,7 @@ void UIObject::ComputeActualSize(const UIObjectSize& inSize, Vec2i& actualSize, 
     }
     else if (IsA<UIStage>())
     {
-        actualSize = ObjCast<UIStage>(this)->GetSurfaceSize();
+        actualSize = DynamicCast<UIStage>(this)->GetSurfaceSize();
     }
     else
     {
@@ -2470,7 +2470,7 @@ void UIObject::UpdateMeshData_Internal()
 
     meshComponent->numInstances = 1;
 
-    Handle<InstancedMeshData> instancedMesh = ObjCast<InstancedMeshData>(meshComponent->instanceData.Resolve());
+    Handle<InstancedMeshData> instancedMesh = DynamicCast<InstancedMeshData>(meshComponent->instanceData.Resolve());
 
     if (!instancedMesh)
     {
@@ -2611,7 +2611,7 @@ ScriptComponent* UIObject::GetScriptComponent(bool deep) const
 
         if (node != nullptr)
         {
-            Entity* entity = ObjCast<Entity>(node);
+            Entity* entity = DynamicCast<Entity>(node);
 
             if (entity != nullptr)
             {
@@ -2716,7 +2716,7 @@ void UIObject::SetNodeProxy(Handle<Node> node)
 
     if (m_node.IsValid())
     {
-        const Handle<Entity>& entity = ObjCast<Entity>(m_node);
+        const Handle<Entity>& entity = DynamicCast<Entity>(m_node);
         Assert(entity != nullptr);
         Assert(entity->HasComponent<UIComponent>());
 
@@ -2730,7 +2730,7 @@ void UIObject::SetNodeProxy(Handle<Node> node)
     {
         Assert(m_node->IsA<Entity>());
 
-        Entity* entity = ObjCast<Entity>(m_node.Get());
+        Entity* entity = DynamicCast<Entity>(m_node.Get());
         entity->AddComponent<UIComponent>(UIComponent { WeakHandleFromThis() });
 
         if (!m_affectsParentSize || !m_isVisible)
@@ -3003,7 +3003,7 @@ void UIObject::ForEachParentUIObject(Lambda&& lambda) const
 
     while (parentNode != nullptr)
     {
-        if (Entity* entity = ObjCast<Entity>(parentNode))
+        if (Entity* entity = DynamicCast<Entity>(parentNode))
         {
             if (UIComponent* uiComponent = entity->TryGetComponent<UIComponent>())
             {
@@ -3170,7 +3170,7 @@ Handle<UIObject> UIObject::CreateUIObject(const Class* cls, Name name, Vec2i pos
     Assert(uiObject != nullptr);
 
     uiObject->m_spawnParent = WeakHandleFromThis();
-    uiObject->m_stage = IsA<UIStage>() ? ObjCast<UIStage>(this) : GetStage();
+    uiObject->m_stage = IsA<UIStage>() ? DynamicCast<UIStage>(this) : GetStage();
 
     uiObject->SetNodeProxy(entity);
     uiObject->SetName(name);

--- a/Source/Engine/ui/UIObject.cpp
+++ b/Source/Engine/ui/UIObject.cpp
@@ -79,10 +79,10 @@ const Handle<Mesh>& UIObjectQuadMeshHelper::GetQuadMesh()
         {
             quad = MeshBuilder::Quad();
             quad->SetFlags(MeshFlags::ViewIndependent);
+            quad->SetName(NAME("UIObject_QuadMesh"));
+            quad->SetIsTransient(true);
 
             // Hack to make vertices be from 0..1 rather than -1..1
-
-            auto readScope = quad->GetReadScope();
 
             VertexArrayView vd = quad->GetVertexData();
             ByteView id = quad->GetIndexData();
@@ -106,17 +106,16 @@ const Handle<Mesh>& UIObjectQuadMeshHelper::GetQuadMesh()
                 vert.posY = (vert.posY + 1.0f) * 0.5f;
             }
 
-            readScope.Reset();
-
             VertexArrayView vertexArrayView {};
             vertexArrayView.floatData = reinterpret_cast<const float*>(newVertices.Data());
             vertexArrayView.vertexCount = newVertices.Size();
             vertexArrayView.layoutDesc = { VT_Simple };
 
             quad->SetMeshData(meshDesc, vertexArrayView, indexData);
-            quad->SetName(NAME("UIObject_QuadMesh"));
 
             InitObject(quad);
+
+            GetEngineAssetRegistry()->PutAsset(quad);
 
             // clean up on engine shutdown
             onShutdownHandle = g_engineDriver->GetDelegates().OnShutdown.Bind([q = &quad]()

--- a/Source/Engine/ui/UIObject.hpp
+++ b/Source/Engine/ui/UIObject.hpp
@@ -560,7 +560,7 @@ public:
     HYP_METHOD()
     HYP_FORCE_INLINE const Handle<Entity>& GetEntity() const
     {
-        return ObjCast<Entity>(m_node);
+        return DynamicCast<Entity>(m_node);
     }
 
     HYP_METHOD()
@@ -918,7 +918,7 @@ public:
     {
         static_assert(std::is_base_of_v<UIObject, T>, "T must be a subclass of UIObject");
 
-        return ObjCast<T>(GetClosestParentUIObject_Proc([](const UIObject* parent) -> bool
+        return DynamicCast<T>(GetClosestParentUIObject_Proc([](const UIObject* parent) -> bool
             {
                 return parent->IsA<T>();
             }));
@@ -929,7 +929,7 @@ public:
     {
         static_assert(std::is_base_of_v<UIObject, T>, "T must be a subclass of UIObject");
 
-        return ObjCast<T>(GetClosestSpawnParent_Proc([](const UIObject* parent) -> bool
+        return DynamicCast<T>(GetClosestSpawnParent_Proc([](const UIObject* parent) -> bool
             {
                 return parent->IsA<T>();
             }));
@@ -1217,7 +1217,7 @@ public:
 
         InitObject(uiObject);
 
-        Handle<T> result = ObjCast<T>(uiObject);
+        Handle<T> result = DynamicCast<T>(uiObject);
         Assert(result.IsValid(), "Failed to cast created UIObject to the requested type");
 
         return result;
@@ -1441,7 +1441,7 @@ private:
 
         Handle<UIObject> uiObject = MakeHandle<T>();
 
-        UIStage* stage = IsA<UIStage>() ? ObjCast<UIStage>(this) : GetStage();
+        UIStage* stage = IsA<UIStage>() ? DynamicCast<UIStage>(this) : GetStage();
 
         uiObject->m_spawnParent = WeakHandleFromThis();
         uiObject->m_stage = stage;

--- a/Source/Engine/ui/UIStage.cpp
+++ b/Source/Engine/ui/UIStage.cpp
@@ -167,11 +167,11 @@ void UIStage::UpdateCameraControllerStack()
 
     for (int i = 0; i < int(controllers.Size()); i++)
     {
-        const auto& controller = controllers[i];
+        const Handle<CameraController>& controller = controllers[i];
 
         if (controller->IsA<UICameraController>())
         {
-            currentController = ObjCast<UICameraController>(controller);
+            currentController = DynamicCast<UICameraController>(controller);
             controllerIndex = i;
             break;
         }
@@ -480,7 +480,7 @@ bool UIStage::TestRay(const Vec2f& position, Array<Handle<UIObject>>& outObjects
 
     for (const RayHit& hit : rayTestResults)
     {
-        if (Entity* entity = ObjCast<Entity>(hit.node))
+        if (Entity* entity = DynamicCast<Entity>(hit.node))
         {
             UIComponent* uiComponent = entity->TryGetComponent<UIComponent>();
 

--- a/Source/Engine/ui/UISubsystem.cpp
+++ b/Source/Engine/ui/UISubsystem.cpp
@@ -102,7 +102,7 @@ static TResult<Handle<FontAtlas>> CreateFontAtlas()
     
     GlobalContextScope contextScope { AssetRegistryContext { MakeStrongRef(&registry) } };
 
-    Handle<FontAtlas> fontAtlas = ObjCast<FontAtlas>(registry.GetAsset(AssetBuckets::FontAtlases, "Roboto_Regular"_sh));
+    Handle<FontAtlas> fontAtlas = DynamicCast<FontAtlas>(registry.GetAsset(AssetBuckets::FontAtlases, "Roboto_Regular"_sh));
 
     if (fontAtlas.IsValid())
     {
@@ -359,7 +359,7 @@ void UISubsystem::RenderCollect(RenderProxyList& rpl)
 
             if ((meshComponent->enableAutoInstancing || meshComponent->numInstances) && meshComponent->instanceData.IsLoaded())
             {
-                const Handle<InstancedMeshData>& instancedMesh = ObjCast<InstancedMeshData>(meshComponent->instanceData.Resolve());
+                const Handle<InstancedMeshData>& instancedMesh = DynamicCast<InstancedMeshData>(meshComponent->instanceData.Resolve());
                 Assert(instancedMesh.IsValid());
 
                 for (uint32 i = 0; i < uint32(instancedMesh->buffers.Size()); i++)

--- a/Source/Engine/ui/UITabView.cpp
+++ b/Source/Engine/ui/UITabView.cpp
@@ -156,7 +156,7 @@ void UITabView::AddChildUIObject(const Handle<UIObject>& uiObject)
         return;
     }
 
-    Handle<UIObject> tab = ObjCast<UITab>(uiObject);
+    Handle<UIObject> tab = DynamicCast<UITab>(uiObject);
     Assert(tab.IsValid(), "Cast to UITab failed");
 
     tab->SetSize(UIObjectSize({ 0, UIObjectSize::AUTO }, { 30, UIObjectSize::PIXEL }));
@@ -180,7 +180,7 @@ void UITabView::AddChildUIObject(const Handle<UIObject>& uiObject)
 
     UIPanel::AddChildUIObject(tab);
 
-    m_tabs.PushBack(ObjCast<UITab>(tab));
+    m_tabs.PushBack(DynamicCast<UITab>(tab));
 
     UpdateTabSizes();
 

--- a/Source/Engine/ui/UIText.cpp
+++ b/Source/Engine/ui/UIText.cpp
@@ -431,13 +431,18 @@ void UIText::UpdateMeshData_Internal()
         meshComponent.instanceData = AssetReference(instancedMesh);
     }
 
-    auto writeScope = instancedMesh->GetWriteScope();
+    // Only update the buffer data if we have any data -- otherwise, setting data to 0 will free all data
+    // and force us to realloc a lot which can chew up a lot of resources doing that at a high frequency
+    if (instanceTransforms.Any())
+    {
+        auto writeScope = instancedMesh->GetWriteScope();
 
-    instancedMesh->SetBufferData(0, instanceTransforms.Data(), instanceTransforms.Size());
-    instancedMesh->SetBufferData(1, instanceTexcoords.Data(), instanceTexcoords.Size());
-    instancedMesh->SetBufferData(2, instanceOffsets.Data(), instanceOffsets.Size());
-    instancedMesh->SetBufferData(3, instanceSizes.Data(), instanceSizes.Size());
-    instancedMesh->SetBufferData(4, instanceProperties.Data(), instanceProperties.Size());
+        instancedMesh->SetBufferData(0, instanceTransforms.Data(), instanceTransforms.Size());
+        instancedMesh->SetBufferData(1, instanceTexcoords.Data(), instanceTexcoords.Size());
+        instancedMesh->SetBufferData(2, instanceOffsets.Data(), instanceOffsets.Size());
+        instancedMesh->SetBufferData(3, instanceSizes.Data(), instanceSizes.Size());
+        instancedMesh->SetBufferData(4, instanceProperties.Data(), instanceProperties.Size());
+    }
 
     GetEntity()->SetNeedsRenderProxyUpdate();
 }

--- a/Source/Engine/ui/UIText.cpp
+++ b/Source/Engine/ui/UIText.cpp
@@ -420,7 +420,7 @@ void UIText::UpdateMeshData_Internal()
 
     meshComponent.numInstances = uint32(instanceTransforms.Size());
     
-    Handle<InstancedMeshData> instancedMesh = ObjCast<InstancedMeshData>(meshComponent.instanceData.Resolve());
+    Handle<InstancedMeshData> instancedMesh = DynamicCast<InstancedMeshData>(meshComponent.instanceData.Resolve());
 
     if (!instancedMesh)
     {

--- a/Source/Shaders/GeometryPass.hlsl
+++ b/Source/Shaders/GeometryPass.hlsl
@@ -100,7 +100,7 @@ DECLARE_BUFFER_DYNAMIC(Default, CBuffer) cbuffer CBuffer
 
 #include "include/Parallax.hlsli"
 
-#define DEBUG_RAW_REFLECTIONS
+// #define DEBUG_RAW_REFLECTIONS
 
 PSOutput PSMain(PSInput input)
 {

--- a/Source/Shaders/Shaders.ini
+++ b/Source/Shaders/Shaders.ini
@@ -23,6 +23,10 @@ VS = deferred/ApplyLightmap.hlsl
 PS = deferred/ApplyFogVolume.hlsl
 VS = deferred/ApplyFogVolume.hlsl
 
+[Sprite]
+PS = sprite/Sprite.hlsl
+VS = sprite/Sprite.hlsl
+
 [Tonemap]
 versions = OUTPUT(PQ_HDR SDR)
 PS = Tonemap.hlsl

--- a/Source/Shaders/Shaders.ini
+++ b/Source/Shaders/Shaders.ini
@@ -28,6 +28,21 @@ versions = OUTPUT(PQ_HDR SDR)
 PS = Tonemap.hlsl
 VS = Tonemap.hlsl
 
+[BloomExtract]
+CS = bloom/BloomExtract.hlsl
+
+[BloomBlur]
+PS = bloom/BloomBlur.hlsl
+VS = bloom/BloomBlur.hlsl
+
+[BloomUpsample]
+PS = bloom/BloomUpsample.hlsl
+VS = bloom/BloomUpsample.hlsl
+
+[BloomDownsample]
+PS = bloom/BloomDownsample.hlsl
+VS = bloom/BloomDownsample.hlsl
+
 [FXAA]
 PS = FXAA.hlsl
 VS = FXAA.hlsl

--- a/Source/Shaders/Shaders.ini
+++ b/Source/Shaders/Shaders.ini
@@ -27,6 +27,10 @@ VS = deferred/ApplyFogVolume.hlsl
 PS = sprite/Sprite.hlsl
 VS = sprite/Sprite.hlsl
 
+[TextSprite]
+PS = sprite/TextSprite.hlsl
+VS = sprite/TextSprite.hlsl
+
 [Tonemap]
 versions = OUTPUT(PQ_HDR SDR)
 PS = Tonemap.hlsl

--- a/Source/Shaders/Tonemap.hlsl
+++ b/Source/Shaders/Tonemap.hlsl
@@ -27,7 +27,6 @@ VSOutput VSMain(VSInput input)
 
     output.position = position.xyz;
     output.texcoord = input.a_texcoord0;
-
     output.position_cs = position;
 
     return output;
@@ -50,6 +49,7 @@ struct PSOutput
 };
 
 DECLARE_SRV(Tonemap, DeferredResult) Texture2D DeferredResult;
+DECLARE_SRV(Tonemap, BloomResultTexture) Texture2D BloomResultTexture;
 
 DECLARE_SAMPLER(Tonemap, SamplerNearest) SamplerState sampler_nearest;
 DECLARE_SAMPLER(Tonemap, SamplerLinear) SamplerState sampler_linear;
@@ -63,8 +63,11 @@ PSOutput PSMain(PSInput input)
     float2 texcoord = input.texcoord;
 
     float4 shaded_result = SAMPLE_TEXTURE_2D(sampler_linear, DeferredResult, texcoord);
+    float4 bloom_result = SAMPLE_TEXTURE_2D(sampler_linear, BloomResultTexture, texcoord);
 
-    float4 color_output = float4(Tonemap(shaded_result.rgb), 1.0);
+    float4 color_with_bloom = shaded_result + bloom_result;
+
+    float4 color_output = float4(Tonemap(color_with_bloom.rgb), 1.0);
 
 #ifdef OUTPUT_PQ_HDR
     const float peakNits = 1000.0;

--- a/Source/Shaders/bloom/BloomBlur.hlsl
+++ b/Source/Shaders/bloom/BloomBlur.hlsl
@@ -1,0 +1,89 @@
+#include "../include/Defines.hlsli"
+
+#include "../include/Shared.hlsli"
+#include "../include/Scene.hlsli"
+#include "../include/Gbuffer.hlsli"
+#include "../include/Packing.hlsli"
+
+#ifdef VERTEX_SHADER
+
+struct VSInput
+{
+    HYP_ATTRIBUTE float3 a_position : POSITION;
+    HYP_ATTRIBUTE float3 a_normal : NORMAL;
+    HYP_ATTRIBUTE float2 a_texcoord0 : TEXCOORD0;
+};
+
+struct VSOutput
+{
+    float4 position_cs : SV_POSITION;
+    float3 position : POSITION;
+    float2 texcoord : TEXCOORD0;
+};
+
+VSOutput VSMain(VSInput input)
+{
+    VSOutput output;
+
+    float4 position = float4(input.a_position, 1.0);
+
+    output.position = position.xyz;
+    output.texcoord = input.a_texcoord0;
+    output.position_cs = position;
+
+    return output;
+}
+
+#endif // VERTEX_SHADER
+
+#ifdef PIXEL_SHADER
+
+struct PSInput
+{
+    float4 position_cs : SV_POSITION;
+    float3 position : POSITION;
+    float2 texcoord : TEXCOORD0;
+};
+
+DECLARE_SAMPLER(BloomBlur, SamplerLinear) SamplerState sampler_linear;
+DECLARE_SAMPLER(BloomBlur, SamplerNearest) SamplerState sampler_nearest;
+
+DECLARE_SRV(BloomBlur, InputTexture) Texture2D InTexture;
+
+DECLARE_BUFFER_DYNAMIC(BloomBlur, CBuffer) cbuffer CBuffer
+{
+    float2 texelSize;
+    float2 padding;
+};
+
+float4 PSMain(PSInput input) : SV_Target0
+{
+    float4 colorSum = float4(0.0f, 0.0f, 0.0f, 0.0f);
+    float weightSum = 0.0f;
+
+    static const float Weights[5] = { 0.0545f, 0.2442f, 0.4026f, 0.2442f, 0.0545f };
+    static const int Radius = 2;
+
+    for (int x = -Radius; x <= Radius; ++x)
+    {
+        for (int y = -Radius; y <= Radius; ++y)
+        {
+            float2 offsetUV = input.texcoord + float2(x, y) * texelSize;
+
+            if (any(offsetUV < float2(0.0f, 0.0f)) || any(offsetUV > float2(1.0f, 1.0f)))
+            {
+                continue;
+            }
+
+            float weight = Weights[x + Radius] * Weights[y + Radius];
+            float4 sampleColor = SAMPLE_TEXTURE_2D(sampler_linear, InTexture, offsetUV);
+
+            colorSum += sampleColor * weight;
+            weightSum += weight;
+        }
+    }
+
+    return colorSum / max(weightSum, 0.001f);
+}
+
+#endif // PIXEL_SHADER

--- a/Source/Shaders/bloom/BloomDownsample.hlsl
+++ b/Source/Shaders/bloom/BloomDownsample.hlsl
@@ -1,0 +1,129 @@
+#include "../include/Defines.hlsli"
+
+#include "../include/Shared.hlsli"
+#include "../include/Scene.hlsli"
+#include "../include/Gbuffer.hlsli"
+#include "../include/Packing.hlsli"
+
+#ifdef VERTEX_SHADER
+
+struct VSInput
+{
+    HYP_ATTRIBUTE float3 a_position : POSITION;
+    HYP_ATTRIBUTE float3 a_normal : NORMAL;
+    HYP_ATTRIBUTE float2 a_texcoord0 : TEXCOORD0;
+};
+
+struct VSOutput
+{
+    float4 position_cs : SV_POSITION;
+    float3 position : POSITION;
+    float2 texcoord : TEXCOORD0;
+};
+
+VSOutput VSMain(VSInput input)
+{
+    VSOutput output;
+
+    float4 position = float4(input.a_position, 1.0);
+
+    output.position = position.xyz;
+    output.texcoord = input.a_texcoord0;
+    output.position_cs = position;
+
+    return output;
+}
+
+#endif // VERTEX_SHADER
+
+#ifdef PIXEL_SHADER
+
+struct PSInput
+{
+    float4 position_cs : SV_POSITION;
+    float3 position : POSITION;
+    float2 texcoord : TEXCOORD0;
+};
+
+DECLARE_SAMPLER(BloomDownsample, SamplerLinear) SamplerState sampler_linear;
+DECLARE_SAMPLER(BloomDownsample, SamplerNearest) SamplerState sampler_nearest;
+
+DECLARE_SRV(BloomDownsample, InputTexture) Texture2D InTexture;
+
+struct DownsampleConstants
+{
+    uint2 srcDimension;
+    uint2 dstDimension;
+    float2 invDimension;
+    float2 padding;
+};
+
+DECLARE_BUFFER_DYNAMIC(BloomDownsample, CBuffer) cbuffer CBuffer
+{
+    DownsampleConstants constants;
+};
+
+float4 PSMain(PSInput input) : SV_Target0
+{
+    float2 srcTexelSize = 1.0f / float2(constants.srcDimension);
+    float2 dstTexelSize = 1.0f / float2(constants.dstDimension);
+
+    float2 srcPixelPos = input.texcoord * float2(constants.srcDimension);
+
+    float4 colorSum = float4(0.0f, 0.0f, 0.0f, 0.0f);
+    float weightSum = 0.0f;
+
+    float2 offsets[13] =
+    {
+        float2(0.0f, 0.0f),
+        float2(-1.0f, 0.0f),
+        float2(1.0f, 0.0f),
+        float2(0.0f, -1.0f),
+        float2(0.0f, 1.0f),
+        float2(-1.0f, -1.0f),
+        float2(1.0f, -1.0f),
+        float2(-1.0f, 1.0f),
+        float2(1.0f, 1.0f),
+        float2(-2.0f, 0.0f),
+        float2(2.0f, 0.0f),
+        float2(0.0f, -2.0f),
+        float2(0.0f, 2.0f)
+    };
+
+    float weights[13] =
+    {
+        0.5f,
+        0.125f,
+        0.125f,
+        0.125f,
+        0.125f,
+        0.0625f,
+        0.0625f,
+        0.0625f,
+        0.0625f,
+        0.0625f,
+        0.0625f,
+        0.0625f,
+        0.0625f
+    };
+
+    for (int i = 0; i < 13; ++i)
+    {
+        float2 samplePixel = srcPixelPos + offsets[i];
+
+        if (any(samplePixel < float2(0.0f, 0.0f)) || any(samplePixel >= float2(constants.srcDimension)))
+        {
+            continue;
+        }
+
+        float2 sampleUV = (samplePixel + 0.5f) / float2(constants.srcDimension);
+        float4 sampleColor = SAMPLE_TEXTURE_2D(sampler_linear, InTexture, sampleUV);
+
+        colorSum += sampleColor * weights[i];
+        weightSum += weights[i];
+    }
+
+    return colorSum / max(weightSum, 0.001f);
+}
+
+#endif // PIXEL_SHADER

--- a/Source/Shaders/bloom/BloomExtract.hlsl
+++ b/Source/Shaders/bloom/BloomExtract.hlsl
@@ -33,7 +33,7 @@ static const float2 LUMINANCE_WEIGHTS = float2(0.2126f, 0.7152f);
 float KarisWeight(float4 c)
 {
     float luma = dot(c.rgb, float3(0.2126f, 0.7152f, 0.0722f));
-    return 1.0f / (1.0f + luma);
+    return 1.0f / (1.0f + max(luma, 1e-5f));
 }
 
 [numthreads(16, 16, 1)]
@@ -74,4 +74,10 @@ void CSMain(uint3 dispatchThreadID : SV_DispatchThreadID)
     contribution = max(contribution, luminance - bloomConstants.threshold);
 
     out_image[coord] = color * (contribution / max(luminance, 1e-5f)) * bloomConstants.intensity;
+    
+    // YUCKY YUCKY YUCK! nans showing up! TODO: track down root cause and fix instead of this band-aid
+    if (any(isnan(out_image[coord])))
+    {
+        out_image[coord] = float4(0.0f, 0.0f, 0.0f, 0.0f);
+    }
 }

--- a/Source/Shaders/bloom/BloomExtract.hlsl
+++ b/Source/Shaders/bloom/BloomExtract.hlsl
@@ -1,0 +1,77 @@
+#include "../include/Defines.hlsli"
+
+PERMUTE(HALFRES);
+
+struct BloomConstants
+{
+    uint2 dimension;
+    float threshold;
+    float intensity;
+    float softKnee;
+};
+
+DECLARE_UAV(BloomExtract, OutImage) RWTexture2D<float4> out_image;
+
+DECLARE_BUFFER_DYNAMIC(BloomExtract, CBuffer) cbuffer CBuffer
+{
+    BloomConstants bloomConstants;
+};
+
+DECLARE_SRV(BloomExtract, DeferredShadingTexture) Texture2D DeferredShadingTexture;
+
+DECLARE_SAMPLER(BloomExtract, SamplerLinear) SamplerState sampler_linear;
+DECLARE_SAMPLER(BloomExtract, SamplerNearest) SamplerState sampler_nearest;
+
+#include "../include/Shared.hlsli"
+#include "../include/Scene.hlsli"
+#include "../include/Gbuffer.hlsli"
+#include "../include/Packing.hlsli"
+
+static const float2 LUMINANCE_WEIGHTS = float2(0.2126f, 0.7152f);
+
+// Karis average weight: 1/(1+luma) down-weights fireflies so they can't blow out bloom.
+float KarisWeight(float4 c)
+{
+    float luma = dot(c.rgb, float3(0.2126f, 0.7152f, 0.0722f));
+    return 1.0f / (1.0f + luma);
+}
+
+[numthreads(16, 16, 1)]
+void CSMain(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    const uint2 coord = dispatchThreadID.xy;
+
+    if (any(coord >= bloomConstants.dimension.xy))
+    {
+        return;
+    }
+
+    // 4-tap 2x2 box filter centred on the pixel, offset by ±0.5 texel so each
+    // tap lands between four source pixels and the GPU hardware bilinear filter
+    // gives us a 4x4 effective footprint. This eliminates the sub-pixel aliasing
+    // that causes flickering when the camera moves.
+    const float2 uv = (float2(coord) + 0.5f) / float2(bloomConstants.dimension.xy);
+    const float2 halfTexel = 0.5f / float2(bloomConstants.dimension.xy);
+
+    float4 s0 = SAMPLE_TEXTURE_2D(sampler_linear, DeferredShadingTexture, uv + float2(-halfTexel.x, -halfTexel.y));
+    float4 s1 = SAMPLE_TEXTURE_2D(sampler_linear, DeferredShadingTexture, uv + float2( halfTexel.x, -halfTexel.y));
+    float4 s2 = SAMPLE_TEXTURE_2D(sampler_linear, DeferredShadingTexture, uv + float2(-halfTexel.x,  halfTexel.y));
+    float4 s3 = SAMPLE_TEXTURE_2D(sampler_linear, DeferredShadingTexture, uv + float2( halfTexel.x,  halfTexel.y));
+
+    // Karis-weighted average suppresses firefly bright spots before thresholding.
+    float w0 = KarisWeight(s0);
+    float w1 = KarisWeight(s1);
+    float w2 = KarisWeight(s2);
+    float w3 = KarisWeight(s3);
+    float4 color = (s0 * w0 + s1 * w1 + s2 * w2 + s3 * w3) / (w0 + w1 + w2 + w3);
+
+    float luminance = dot(color.rgb, float3(LUMINANCE_WEIGHTS.x, LUMINANCE_WEIGHTS.y, 1.0f - LUMINANCE_WEIGHTS.x - LUMINANCE_WEIGHTS.y));
+
+    // Soft-knee threshold (UE4-style)
+    float knee = bloomConstants.threshold * bloomConstants.softKnee;
+    float b = clamp(luminance - bloomConstants.threshold + knee, 0.0f, 2.0f * knee);
+    float contribution = (knee > 0.0f) ? (0.25f * b * b / knee) : max(0.0f, luminance - bloomConstants.threshold);
+    contribution = max(contribution, luminance - bloomConstants.threshold);
+
+    out_image[coord] = color * (contribution / max(luminance, 1e-5f)) * bloomConstants.intensity;
+}

--- a/Source/Shaders/bloom/BloomUpsample.hlsl
+++ b/Source/Shaders/bloom/BloomUpsample.hlsl
@@ -1,0 +1,115 @@
+#include "../include/Defines.hlsli"
+
+#include "../include/Shared.hlsli"
+#include "../include/Scene.hlsli"
+#include "../include/Gbuffer.hlsli"
+#include "../include/Packing.hlsli"
+
+#ifdef VERTEX_SHADER
+
+struct VSInput
+{
+    HYP_ATTRIBUTE float3 a_position : POSITION;
+    HYP_ATTRIBUTE float3 a_normal : NORMAL;
+    HYP_ATTRIBUTE float2 a_texcoord0 : TEXCOORD0;
+};
+
+struct VSOutput
+{
+    float4 position_cs : SV_POSITION;
+    float3 position : POSITION;
+    float2 texcoord : TEXCOORD0;
+};
+
+VSOutput VSMain(VSInput input)
+{
+    VSOutput output;
+
+    float4 position = float4(input.a_position, 1.0);
+
+    output.position = position.xyz;
+    output.texcoord = input.a_texcoord0;
+    output.position_cs = position;
+
+    return output;
+}
+
+#endif // VERTEX_SHADER
+
+#ifdef PIXEL_SHADER
+
+struct PSInput
+{
+    float4 position_cs : SV_POSITION;
+    float3 position : POSITION;
+    float2 texcoord : TEXCOORD0;
+};
+
+DECLARE_SAMPLER(BloomUpsample, SamplerLinear) SamplerState sampler_linear;
+DECLARE_SAMPLER(BloomUpsample, SamplerNearest) SamplerState sampler_nearest;
+
+DECLARE_SRV(BloomUpsample, PrevPassTexture) Texture2D PrevPassTexture;
+DECLARE_SRV(BloomUpsample, InputTexture) Texture2D InTexture;
+
+DECLARE_BUFFER_DYNAMIC(BloomUpsample, CBuffer) cbuffer CBuffer
+{
+    float2 texelSize;
+    float scatter; // blend factor between coarser and finer mip (0.5 = equal weight)
+    float padding;
+};
+
+float4 SampleWithTentFilter(Texture2D tex, SamplerState sampler, float2 uv, float2 texelSize)
+{
+    // 3x3 tent (bilinear) filter. Weights sum to 1, so no normalisation needed.
+    // Luminance-weighted (Karis) sampling is intentionally NOT used here — it
+    // belongs only on the first downsample pass. Applying it during upsample
+    // would bias the blend toward bright areas and produce uneven bloom energy.
+    static const float TentWeights[9] =
+    {
+        0.0625f, 0.125f, 0.0625f,
+        0.125f,  0.25f,  0.125f,
+        0.0625f, 0.125f, 0.0625f
+    };
+
+    float4 colorSum = float4(0.0f, 0.0f, 0.0f, 0.0f);
+    float weightSum = 0.0f;
+
+    int idx = 0;
+    for (int y = -1; y <= 1; ++y)
+    {
+        for (int x = -1; x <= 1; ++x)
+        {
+            float2 offsetUV = uv + float2(x, y) * texelSize;
+
+            if (any(offsetUV < float2(0.0f, 0.0f)) || any(offsetUV > float2(1.0f, 1.0f)))
+            {
+                idx++;
+                continue;
+            }
+
+            float weight = TentWeights[idx];
+            colorSum += SAMPLE_TEXTURE_2D(sampler, tex, offsetUV) * weight;
+            weightSum += weight;
+            idx++;
+        }
+    }
+
+    // Normalise so skipped out-of-bounds taps at image edges don't dim the result
+    return colorSum / max(weightSum, 0.0001f);
+}
+
+float4 PSMain(PSInput input) : SV_Target0
+{
+    float2 uv = input.texcoord;
+
+    float2 upsampleTexelSize = texelSize * 2.0f;
+    float4 upsampledColor = SampleWithTentFilter(PrevPassTexture, sampler_linear, uv, upsampleTexelSize);
+    float4 blendColor = SAMPLE_TEXTURE_2D(sampler_linear, InTexture, uv);
+
+    // Lerp between the current mip (fine detail) and the accumulated upsampled result
+    // (coarser, wider spread). scatter=0.5 gives equal weight to each pyramid level,
+    // producing a natural falloff rather than a uniform halo.
+    return lerp(blendColor, upsampledColor, scatter);
+}
+
+#endif // PIXEL_SHADER

--- a/Source/Shaders/include/Tonemap.hlsli
+++ b/Source/Shaders/include/Tonemap.hlsli
@@ -7,12 +7,12 @@
 //#define HDR_TONEMAP_UNCHARTED 1
 //#define HDR_TONEMAP_FILMIC 1
 //#define HDR_TONEMAP_LOTTES 1
-//#define HDR_TONEMAP_UNREAL 1
+// #define HDR_TONEMAP_UNREAL 1
 //#define HDR_TONEMAP_REINHARD 1
 #define HDR_TONEMAP_ACES 1
 
 #ifndef EXPOSURE
-#define EXPOSURE 1.0
+#define EXPOSURE 1.25
 #endif
 
 // Source for some of these: https://dmnsgn.github.io/glsl-tone-map

--- a/Source/Shaders/sprite/Sprite.hlsl
+++ b/Source/Shaders/sprite/Sprite.hlsl
@@ -1,0 +1,103 @@
+#include "../include/Defines.hlsli"
+#include "../include/Shared.hlsli"
+#include "../include/Entity.hlsli"
+#include "../include/GBuffer.hlsli"
+#include "./Sprite.hlsli"
+
+PERMUTE(SPRITE);
+
+STATIC(INSTANCING);
+
+#ifdef VERTEX_SHADER
+
+struct VSInput
+{
+    HYP_ATTRIBUTE float3 a_position : POSITION;
+    HYP_ATTRIBUTE float3 a_normal : NORMAL;
+    HYP_ATTRIBUTE float2 a_texcoord0 : TEXCOORD0;
+};
+
+struct VSOutput
+{
+    float4 position_cs : SV_POSITION;
+    float2 texcoord0 : TEXCOORD0;
+    float4 color : TEXCOORD1;
+};
+
+#include "../include/Scene.hlsli"
+
+DECLARE_SRV_DYNAMIC(Default, CamerasBuffer) StructuredBuffer<Camera> _cameras_buffer;
+#define camera _cameras_buffer[0]
+
+DECLARE_BUFFER_DYNAMIC(Default, CBuffer) cbuffer CBuffer
+{
+    Entity entity;
+};
+
+DECLARE_SRV_DYNAMIC(Default, SpriteInstanceBuffer) StructuredBuffer<SpriteInstanceData> SpriteInstanceBuffer;
+
+struct SpriteInstanceData
+{
+    float4 positionSize;
+    float4 color;
+};
+
+VSOutput VSMain(VSInput input, uint instanceId : SV_InstanceID)
+{
+    VSOutput output;
+
+    SpriteInstanceData instance = SpriteInstanceBuffer[instanceId];
+
+    float3 center = instance.positionSize.xyz;
+    float size = instance.positionSize.w;
+
+    float3 localPos = float3((input.a_position.x - 0.5f) * size, (input.a_position.y - 0.5f) * size, 0.0f);
+
+    float3 worldPos = center + localPos;
+
+    float4 ndcPos = mul(camera.viewProjMat, float4(worldPos, 1.0));
+
+    output.position_cs = ndcPos;
+    output.texcoord0 = input.a_texcoord0;
+    output.color = instance.color;
+
+    return output;
+}
+
+#endif // VERTEX_SHADER
+
+#ifdef PIXEL_SHADER
+
+struct PSInput
+{
+    float4 position_cs : SV_POSITION;
+    float2 texcoord0 : TEXCOORD0;
+    float4 color : TEXCOORD1;
+};
+
+struct PSOutput
+{
+    float4 gbuffer_albedo : SV_Target0;
+    float4 gbuffer_normals : SV_Target1;
+    uint4 gbuffer_material : SV_Target2;
+    float2 gbuffer_velocity : SV_Target3;
+};
+
+DECLARE_BUFFER_DYNAMIC(Default, CBuffer) cbuffer CBuffer
+{
+    Material material;
+};
+
+PSOutput PSMain(PSInput input)
+{
+    PSOutput output;
+
+    output.gbuffer_albedo = float4(1.0, 0.0, 0.0, 1.0);//input.color * material.albedo;
+    output.gbuffer_normals = GBufferPackNormal(float3(0.5f, 0.5f, 1.0f));
+    output.gbuffer_material = uint4(0, 0, 0, 0);
+    output.gbuffer_velocity = float2(0.0f, 0.0f);
+
+    return output;
+}
+
+#endif // PIXEL_SHADER

--- a/Source/Shaders/sprite/Sprite.hlsl
+++ b/Source/Shaders/sprite/Sprite.hlsl
@@ -30,6 +30,7 @@ struct SpriteInstanceData
 {
     float4 positionSize;
     float4 color;
+    uint4 flags; // x = alwaysFaceCamera
 };
 
 DECLARE_SRV(Sprite, SpriteInstanceBuffer) StructuredBuffer<SpriteInstanceData> SpriteInstanceBuffer;
@@ -43,13 +44,24 @@ VSOutput VSMain(VSInput input, uint instanceId : SV_InstanceID)
     float3 center = instance.positionSize.xyz;
     float size = instance.positionSize.w;
 
-    float3 localPos = float3((input.a_position.x - 0.5f) * size, (input.a_position.y - 0.5f) * size, 0.0f);
+    float3 worldPos;
 
-    float3 worldPos = center + localPos;
+    if (instance.flags.x != 0u)
+    {
+        float3 camRight = float3(camera.view[0][0], camera.view[0][1], camera.view[0][2]);
+        float3 camUp = float3(camera.view[1][0], camera.view[1][1], camera.view[1][2]);
 
-    float4 ndcPos = mul(camera.viewProjMat, float4(worldPos, 1.0));
+        worldPos = center
+            + camRight * (input.a_position.x - 0.5f) * size
+            + camUp * (input.a_position.y - 0.5f) * size;
+    }
+    else
+    {
+        float3 localPos = float3((input.a_position.x - 0.5f) * size, (input.a_position.y - 0.5f) * size, 0.0f);
+        worldPos = center + localPos;
+    }
 
-    output.position_cs = ndcPos;
+    output.position_cs = mul(camera.viewProjMat, float4(worldPos, 1.0));
     output.texcoord0 = input.a_texcoord0;
     output.color = instance.color;
 

--- a/Source/Shaders/sprite/Sprite.hlsl
+++ b/Source/Shaders/sprite/Sprite.hlsl
@@ -2,11 +2,8 @@
 #include "../include/Shared.hlsli"
 #include "../include/Entity.hlsli"
 #include "../include/GBuffer.hlsli"
+#include "../include/Scene.hlsli"
 #include "./Sprite.hlsli"
-
-PERMUTE(SPRITE);
-
-STATIC(INSTANCING);
 
 #ifdef VERTEX_SHADER
 
@@ -24,23 +21,18 @@ struct VSOutput
     float4 color : TEXCOORD1;
 };
 
-#include "../include/Scene.hlsli"
-
-DECLARE_SRV_DYNAMIC(Default, CamerasBuffer) StructuredBuffer<Camera> _cameras_buffer;
-#define camera _cameras_buffer[0]
-
-DECLARE_BUFFER_DYNAMIC(Default, CBuffer) cbuffer CBuffer
+DECLARE_BUFFER_DYNAMIC(Sprite, CBuffer) cbuffer CBuffer
 {
-    Entity entity;
+    Camera camera;
 };
-
-DECLARE_SRV_DYNAMIC(Default, SpriteInstanceBuffer) StructuredBuffer<SpriteInstanceData> SpriteInstanceBuffer;
 
 struct SpriteInstanceData
 {
     float4 positionSize;
     float4 color;
 };
+
+DECLARE_SRV(Sprite, SpriteInstanceBuffer) StructuredBuffer<SpriteInstanceData> SpriteInstanceBuffer;
 
 VSOutput VSMain(VSInput input, uint instanceId : SV_InstanceID)
 {
@@ -83,16 +75,11 @@ struct PSOutput
     float2 gbuffer_velocity : SV_Target3;
 };
 
-DECLARE_BUFFER_DYNAMIC(Default, CBuffer) cbuffer CBuffer
-{
-    Material material;
-};
-
 PSOutput PSMain(PSInput input)
 {
     PSOutput output;
 
-    output.gbuffer_albedo = float4(1.0, 0.0, 0.0, 1.0);//input.color * material.albedo;
+    output.gbuffer_albedo = input.color;
     output.gbuffer_normals = GBufferPackNormal(float3(0.5f, 0.5f, 1.0f));
     output.gbuffer_material = uint4(0, 0, 0, 0);
     output.gbuffer_velocity = float2(0.0f, 0.0f);

--- a/Source/Shaders/sprite/Sprite.hlsli
+++ b/Source/Shaders/sprite/Sprite.hlsli
@@ -1,0 +1,6 @@
+#ifndef SPRITE_HLSLI
+#define SPRITE_HLSLI
+
+#define PROPERTY_SPRITE 0
+
+#endif // SPRITE_HLSLI

--- a/Source/Shaders/sprite/TextSprite.hlsl
+++ b/Source/Shaders/sprite/TextSprite.hlsl
@@ -7,12 +7,20 @@
 
 struct TextSpriteInstanceData
 {
+    // 0
     float4x4 transform;
-    float4 color;
-    float4 texcoordStart;
-    float4 texcoordEnd;
+    // 64
+    float2 texcoordStart;
+    // 72
+    float2 texcoordEnd;
+    // 80
     uint textureIndex;
-    float2 _pad;
+    // 84
+    uint colorPacked;
+    uint _pad1;
+    uint _pad2;
+
+    // 96
 };
 
 DECLARE_SRV(TextSprite, TextSpriteInstanceBuffer) StructuredBuffer<TextSpriteInstanceData> TextSpriteInstanceBuffer;
@@ -31,6 +39,7 @@ struct VSOutput
     float4 position_cs : SV_POSITION;
     float2 texcoord0 : TEXCOORD0;
     float4 color : TEXCOORD1;
+    uint instanceId : TEXCOORD2;
 };
 
 DECLARE_BUFFER_DYNAMIC(TextSprite, CBuffer) cbuffer CBuffer
@@ -45,14 +54,16 @@ VSOutput VSMain(VSInput input, uint instanceId : SV_InstanceID)
     TextSpriteInstanceData instance = TextSpriteInstanceBuffer[instanceId];
 
     float3 localPos = float3(input.a_position.x - 0.5f, input.a_position.y - 0.5f, 0.0f);
-    float3 worldPos = mul(instance.transform, float4(localPos, 1.0f)).xyz;
 
-    output.position_cs = mul(camera.viewProjMat, float4(worldPos, 1.0f));
+    float4 worldPos = mul(instance.transform, float4(localPos, 1.0f));
+    output.position_cs = mul(camera.viewProjMat, worldPos);
+
     output.texcoord0 = float2(
         lerp(instance.texcoordStart.x, instance.texcoordEnd.x, input.a_texcoord0.x),
         lerp(instance.texcoordStart.y, instance.texcoordEnd.y, input.a_texcoord0.y)
     );
-    output.color = instance.color;
+    output.color = UINT_TO_VEC4(instance.colorPacked);
+    output.instanceId = instanceId;
 
     return output;
 }
@@ -68,6 +79,7 @@ struct PSInput
     float4 position_cs : SV_POSITION;
     float2 texcoord0 : TEXCOORD0;
     float4 color : TEXCOORD1;
+    uint instanceId : TEXCOORD2;
 };
 
 struct PSOutput
@@ -84,11 +96,11 @@ DECLARE_SRV(BindlessResources0, Textures) Texture2D<float4> fontTextures[];
 DECLARE_SRV(TextSprite, FontTexture) Texture2D<float4> FontTexture;
 #endif
 
-PSOutput PSMain(PSInput input, uint instanceId : SV_InstanceID)
+PSOutput PSMain(PSInput input)
 {
     PSOutput output;
 
-    TextSpriteInstanceData instance = TextSpriteInstanceBuffer[instanceId];
+    TextSpriteInstanceData instance = TextSpriteInstanceBuffer[input.instanceId];
 
 #ifdef HYP_FEATURES_BINDLESS_TEXTURES
     float4 texColor = (float4)0;

--- a/Source/Shaders/sprite/TextSprite.hlsl
+++ b/Source/Shaders/sprite/TextSprite.hlsl
@@ -1,0 +1,120 @@
+#include "../include/Defines.hlsli"
+#include "../include/Shared.hlsli"
+#include "../include/Entity.hlsli"
+#include "../include/GBuffer.hlsli"
+#include "../include/Scene.hlsli"
+#include "./Sprite.hlsli"
+
+struct TextSpriteInstanceData
+{
+    float4x4 transform;
+    float4 color;
+    float4 texcoordStart;
+    float4 texcoordEnd;
+    uint textureIndex;
+    float2 _pad;
+};
+
+DECLARE_SRV(TextSprite, TextSpriteInstanceBuffer) StructuredBuffer<TextSpriteInstanceData> TextSpriteInstanceBuffer;
+
+#ifdef VERTEX_SHADER
+
+struct VSInput
+{
+    HYP_ATTRIBUTE float3 a_position : POSITION;
+    HYP_ATTRIBUTE float3 a_normal : NORMAL;
+    HYP_ATTRIBUTE float2 a_texcoord0 : TEXCOORD0;
+};
+
+struct VSOutput
+{
+    float4 position_cs : SV_POSITION;
+    float2 texcoord0 : TEXCOORD0;
+    float4 color : TEXCOORD1;
+};
+
+DECLARE_BUFFER_DYNAMIC(TextSprite, CBuffer) cbuffer CBuffer
+{
+    Camera camera;
+};
+
+VSOutput VSMain(VSInput input, uint instanceId : SV_InstanceID)
+{
+    VSOutput output;
+
+    TextSpriteInstanceData instance = TextSpriteInstanceBuffer[instanceId];
+
+    float3 localPos = float3(input.a_position.x - 0.5f, input.a_position.y - 0.5f, 0.0f);
+    float3 worldPos = mul(instance.transform, float4(localPos, 1.0f)).xyz;
+
+    output.position_cs = mul(camera.viewProjMat, float4(worldPos, 1.0f));
+    output.texcoord0 = float2(
+        lerp(instance.texcoordStart.x, instance.texcoordEnd.x, input.a_texcoord0.x),
+        lerp(instance.texcoordStart.y, instance.texcoordEnd.y, input.a_texcoord0.y)
+    );
+    output.color = instance.color;
+
+    return output;
+}
+
+#endif // VERTEX_SHADER
+
+#ifdef PIXEL_SHADER
+
+DECLARE_SAMPLER(TextSprite, SamplerLinear) SamplerState sampler_linear;
+
+struct PSInput
+{
+    float4 position_cs : SV_POSITION;
+    float2 texcoord0 : TEXCOORD0;
+    float4 color : TEXCOORD1;
+};
+
+struct PSOutput
+{
+    float4 gbuffer_albedo : SV_Target0;
+    float4 gbuffer_normals : SV_Target1;
+    uint4 gbuffer_material : SV_Target2;
+    float2 gbuffer_velocity : SV_Target3;
+};
+
+#ifdef HYP_FEATURES_BINDLESS_TEXTURES
+DECLARE_SRV(BindlessResources0, Textures) Texture2D<float4> fontTextures[];
+#else
+DECLARE_SRV(TextSprite, FontTexture) Texture2D<float4> FontTexture;
+#endif
+
+PSOutput PSMain(PSInput input, uint instanceId : SV_InstanceID)
+{
+    PSOutput output;
+
+    TextSpriteInstanceData instance = TextSpriteInstanceBuffer[instanceId];
+
+#ifdef HYP_FEATURES_BINDLESS_TEXTURES
+    float4 texColor = (float4)0;
+    
+    if (instance.textureIndex != ~0u)
+    {
+        texColor = fontTextures[instance.textureIndex].Sample(sampler_linear, input.texcoord0);
+    }
+#else
+    float4 texColor = FontTexture.Sample(sampler_linear, input.texcoord0);
+#endif
+
+    float4 color = input.color;
+    // color.rgb *= texColor.a;
+
+    if (texColor.a < 0.01f)
+    {
+        // discard;
+    }
+
+    output.gbuffer_albedo = color;
+    output.gbuffer_normals = GBufferPackNormal(float3(0.5f, 0.5f, 1.0f));
+    output.gbuffer_material = uint4(0, 0, 0, 0);
+    output.gbuffer_velocity = float2(0.0f, 0.0f);
+
+    return output;
+}
+
+#endif // PIXEL_SHADER

--- a/Source/Shaders/sprite/TextSprite.hlsl
+++ b/Source/Shaders/sprite/TextSprite.hlsl
@@ -60,7 +60,7 @@ VSOutput VSMain(VSInput input, uint instanceId : SV_InstanceID)
 
     output.texcoord0 = float2(
         lerp(instance.texcoordStart.x, instance.texcoordEnd.x, input.a_texcoord0.x),
-        lerp(instance.texcoordStart.y, instance.texcoordEnd.y, input.a_texcoord0.y)
+        lerp(instance.texcoordEnd.y, instance.texcoordStart.y, input.a_texcoord0.y)
     );
     output.color = UINT_TO_VEC4(instance.colorPacked);
     output.instanceId = instanceId;

--- a/Source/Shaders/sprite/TextSprite.hlsl
+++ b/Source/Shaders/sprite/TextSprite.hlsl
@@ -53,7 +53,7 @@ VSOutput VSMain(VSInput input, uint instanceId : SV_InstanceID)
 
     TextSpriteInstanceData instance = TextSpriteInstanceBuffer[instanceId];
 
-    float3 localPos = float3(input.a_position.x - 0.5f, input.a_position.y - 0.5f, 0.0f);
+    float3 localPos = input.a_position;
 
     float4 worldPos = mul(instance.transform, float4(localPos, 1.0f));
     output.position_cs = mul(camera.viewProjMat, worldPos);
@@ -109,22 +109,26 @@ PSOutput PSMain(PSInput input)
     {
         texColor = fontTextures[instance.textureIndex].Sample(sampler_linear, input.texcoord0);
     }
+    else
+    {
+        texColor = float4(1.0f, 0.0f, 1.0f, 1.0f); // jsut so we can see when something is wrong with the texture index
+    }
 #else
     float4 texColor = FontTexture.Sample(sampler_linear, input.texcoord0);
 #endif
 
     float4 color = input.color;
-    // color.rgb *= texColor.a;
+    color *= texColor.r;
 
-    if (texColor.a < 0.01f)
+    if (color.a < 0.01f)
     {
-        // discard;
+        discard;
     }
 
     output.gbuffer_albedo = color;
     output.gbuffer_normals = GBufferPackNormal(float3(0.5f, 0.5f, 1.0f));
     output.gbuffer_material = uint4(0, 0, 0, 0);
-    output.gbuffer_velocity = float2(0.0f, 0.0f);
+    output.gbuffer_velocity = float2(0, 0);
 
     return output;
 }


### PR DESCRIPTION
Adds new types (TextSprite, Sprite) to allow rendering of 2D textures or text in the 3D world. Currently the goal is for this to be used for Editor sprites showing where entities like cameras, volumes etc. are.

## AI usage disclaimer
Used Claude Sonnet 4.6 and Minimax M2.5 with Opencode and Copilot to generate scaffolding